### PR TITLE
Require audb>=1.5.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audb >=1.5.1
+    audb >=1.5.2
     audplot >=1.4.6
 python_requires = >=3.8
 setup_requires =


### PR DESCRIPTION
`audb` 1.5.2 fixed the order of how files are stored inside the dependency table during publishing.
This makes it easier to get the same result without ordering and we could simply use this feature in `audbcards`.