### PR TITLE
Add Dataset.segments + Dataset.segment_durations

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -19,7 +19,7 @@ from audbcards.core.utils import limit_presented_samples
 
 
 class _Dataset:
-    _table_properties = ["segment_durations", "segments"]
+    _table_related_cached_properties = ["segment_durations", "segments"]
     """Cached properties relying on table data.
 
     Most of the cached properties
@@ -35,7 +35,7 @@ class _Dataset:
     to avoid loading of the tables.
 
     To make ``load_tables`` work,
-    ``_table_properties`` has to list all cached properties,
+    ``_table_related_cached_properties`` has to list all cached properties,
     that will load filewise or segmented tables.
 
     """
@@ -58,20 +58,20 @@ class _Dataset:
             obj = cls._load_pickled(dataset_cache_filename)
             # `load_tables` is not stored in cache
             obj._load_tables = load_tables
-            # Load table properties,
-            # if requested,
-            # and store them in cache,
-            # if not cached before
+            # Load cached properties,
+            # that require to load filewise or segmented tables,
+            # if they haven't been cached before.
             if load_tables:
                 cache_again = False
-                for table_property in cls._table_properties:
+                for cached_property in cls._table_properties:
                     # Check if property has been cached,
                     # see https://stackoverflow.com/a/59740750
-                    if table_property not in obj.__dict__:
+                    if cached_property not in obj.__dict__:
                         cache_again = True
                         # Request property to fill their cached value
-                        getattr(obj, table_property)
+                        getattr(obj, cached_property)
                 if cache_again:
+                    # Update cache to store the table related cached properties
                     cls._save_pickled(obj, dataset_cache_filename)
 
             return obj
@@ -486,7 +486,7 @@ class _Dataset:
         """
         exclude = []
         if not self._load_tables:
-            exclude = self._table_properties
+            exclude = self._table_related_cached_properties
         class_items = self.__class__.__dict__.items()
         props = dict(
             (k, getattr(self, k))

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -566,13 +566,17 @@ class _Dataset:
     @functools.cached_property
     def _segments(self) -> pd.MultiIndex:
         """Segments of dataset as combined index."""
-        return audformat.utils.union(
-            [
-                audb.load_table(self.name, table_id, version=self.version).index
-                for table_id, table in self.header.tables.items()
-                if table.is_segmented
-            ]
-        )
+        index = audformat.segmented_index()
+        for table in self.header.tables:
+            if self.header.tables[table].is_segmented:
+                df = audb.load_table(
+                    self.name,
+                    table,
+                    version=self.version,
+                    verbose=False,
+                )
+                index = audformat.utils.union([index, df.index])
+        return index
 
     @staticmethod
     def _map_iso_languages(languages: typing.List[str]) -> typing.List[str]:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -682,7 +682,7 @@ class Dataset(object):
             it caches values extracted from tables.
             Set this to ``False``,
             if loading the tables takes too long,
-            or will not fit into memory
+            or does not fit into memory
 
     """
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -28,15 +28,24 @@ class _Dataset:
     and misc tables used as scheme labels.
     Some might also need to load filewise or segmented tables,
     to gather more information.
-    As this process can be slow,
-    or crash,
-    when tables do not fit into memory,
-    we provide the ``load_tables`` argument in ``audbcards.Dataset``
-    to avoid loading of the tables.
 
-    To make ``load_tables`` work,
+    Persistence of table related cached properties
+    depends on the ``load_tables`` argument
+    of :class:`audbcards.Dataset`.
+    When ``load_tables`` is ``True``
+    :meth:`audbcards.Dataset._cached_properties`
+    is asked to cache table related cached properties as well.
+    It infers the table related properties
+    from ``_table_related_cached_properties``.
+    Which means,
     ``_table_related_cached_properties`` has to list all cached properties,
     that will load filewise or segmented tables.
+
+    If a dataset exists in cache,
+    but does not store table related cached properties,
+    a call to :class:`audbcards.Dataset`
+    with ``load_tables`` is ``True``,
+    will update the cache.
 
     """
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -363,6 +363,18 @@ class _Dataset:
         return scheme_data
 
     @functools.cached_property
+    def segments(self) -> str:
+        r"""Number of segments in dataset."""
+        index = audformat.utils.union(
+            [
+                audb.load_table(self.name, table_id, version=self.version).index
+                for table_id, table in self.header.tables.items()
+                if table.is_segmented
+            ]
+        )
+        return str(len(index))
+
+    @functools.cached_property
     def short_description(self) -> str:
         r"""Description of dataset shortened to 150 chars."""
         length = 150

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -63,7 +63,7 @@ class _Dataset:
             # if they haven't been cached before.
             if load_tables:
                 cache_again = False
-                for cached_property in cls._table_properties:
+                for cached_property in cls._table_related_cached_properties:
                     # Check if property has been cached,
                     # see https://stackoverflow.com/a/59740750
                     if cached_property not in obj.__dict__:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -53,7 +53,7 @@ class _Dataset:
         if os.path.exists(dataset_cache_filename):
             obj = cls._load_pickled(dataset_cache_filename)
             # `load_tables` is not stored in cache
-            obj.load_tables = load_tables
+            obj._load_tables = load_tables
             # Load table properties,
             # if requested,
             # and store them in cache,
@@ -89,8 +89,8 @@ class _Dataset:
         self.cache_root = audeer.mkdir(cache_root)
         r"""Cache root folder."""
 
-        self.load_tables = load_tables
-        r"""If ``True`` cache only information extracted from header."""
+        # Private attribute used in ``self._cached_properties()``
+        self._load_tables = load_tables
 
         # Store name and version in private attributes here,
         # ``self.name`` and ``self.version``
@@ -481,7 +481,7 @@ class _Dataset:
 
         """
         exclude = []
-        if not self.load_tables:
+        if not self._load_tables:
             exclude = self._table_properties
         class_items = self.__class__.__dict__.items()
         props = dict(
@@ -711,9 +711,6 @@ class Dataset(object):
     ):
         self.cache_root = audeer.mkdir(cache_root)
         r"""Cache root folder."""
-
-        self.load_tables = load_tables
-        r"""If ``True``, dataset tables have been loaded."""
 
     # Copy attributes and methods
     # to include in documentation

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -24,15 +24,19 @@ class _Dataset:
 
     Most of the cached properties
     rely on the dependency table,
-    and the header of a dataset.
-    Some might also need to load tables
+    the header of a dataset,
+    and misc tables used as scheme labels.
+    Some might also need to load filewise or segmented tables,
     to gather more information.
     As this process can be slow,
     or crash,
     when tables do not fit into memory,
-    we collect them here,
-    in order to switch loading of tables off
-    in `audbcards.Dataset`.
+    we provide the ``load_tables`` argument in ``audbcards.Dataset``
+    to avoid loading of the tables.
+
+    To make ``load_tables`` work,
+    ``_table_properties`` has to list all cached properties,
+    that will load filewise or segmented tables.
 
     """
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -184,6 +184,10 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     ]
     assert dataset.schemes_table == expected_schemes_table
 
+    # segment_durations
+    expected_segment_durations = [0.5, 0.5, 150, 151]
+    assert dataset.segment_durations == expected_segment_durations
+
     # segments
     expected_segments = str(len(db.segments))
     assert dataset.segments == expected_segments

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -455,8 +455,8 @@ def test_dataset_cache_loading(audb_cache, tmpdir, repository, db, request):
 class TestDatasetLoadTables:
     r"""Test load_tables argument of audbcards.Dataset."""
 
-    @pytest.fixture(autouse=True)
     @classmethod
+    @pytest.fixture(autouse=True)
     def setup(cls, cache, medium_db):
         r"""Provide test class with cache and database.
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -456,7 +456,8 @@ class TestDatasetLoadTables:
     r"""Test load_tables argument of audbcards.Dataset."""
 
     @pytest.fixture(autouse=True)
-    def setup(self, cache, medium_db):
+    @classmethod
+    def setup(cls, cache, medium_db):
         r"""Provide test class with cache and database.
 
         Args:
@@ -464,9 +465,9 @@ class TestDatasetLoadTables:
             medium_db: medium_db fixture
 
         """
-        self.name = medium_db.name
-        self.version = pytest.VERSION
-        self.cache_root = cache
+        cls.name = medium_db.name
+        cls.version = pytest.VERSION
+        cls.cache_root = cache
 
     def assert_has_table_properties(self, expected: bool):
         r"""Assert dataset holds table related cached properties.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -508,14 +508,14 @@ class TestDatasetLoadTables:
 
         This tests if the table related arguments
         are stored or omitted in cache,
-        dependent of the ``load_tables`` argument.
+        dependent on the ``load_tables`` argument.
 
         It also loads the dataset another two times from cache,
         with changing ``load_tables``
         arguments,
         which should always result
         in existing table related properties,
-        as a cache stord first with ``load_tables=False``,
+        as a cache stored first with ``load_tables=False``,
         should be updated when loading again with ``load_tables=True``.
 
         Args:
@@ -523,9 +523,6 @@ class TestDatasetLoadTables:
                 it calls ``audbcards.Dataset``
                 with ``load_tables=True``
                 during it first call
-                and with ``load_tables=False``
-                during its second call;
-                and vice versa if ``False``
 
         """
         self.load_dataset(load_tables=load_tables_first)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -458,7 +458,7 @@ class TestDatasetLoadTables:
     @classmethod
     @pytest.fixture(autouse=True)
     def setup(cls, cache, medium_db):
-        r"""Provide test class with cache and database.
+        r"""Provide test class with cache, database name and database version.
 
         Args:
             cache: cache fixture
@@ -489,6 +489,8 @@ class TestDatasetLoadTables:
 
     def load_dataset(self, *, load_tables: bool):
         r"""Load dataset.
+
+        Call ``audbcards.Dataset`` and assign result to ``self.dataset``.
 
         Args:
             load_tables: if ``True``,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -184,6 +184,10 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     ]
     assert dataset.schemes_table == expected_schemes_table
 
+    # segments
+    expected_segments = str(len(db.segments))
+    assert dataset.segments == expected_segments
+
     # short_description
     max_desc_length = 150
     expected_description = (

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -502,36 +502,35 @@ class TestDatasetLoadTables:
             load_tables=load_tables,
         )
 
-    def test_load_tables_first(self):
-        r"""Load and dataset with table related properties.
+    @pytest.mark.parametrize("load_tables_first", [True, False])
+    def test_load_tables(self, load_tables_first):
+        r"""Load dataset with/without table related properties.
 
-        This instantiates the dataset
-        the first time with ``load_tables=True``,
-        which should cache table related properties.
-        When loading the dataset
-        afterwards with ``load_tables=False``,
-        the table related properties
-        should still be loaded.
+        This tests if the table related arguments
+        are stored or omitted in cache,
+        dependent of the ``load_tables`` argument.
 
-        """
-        self.load_dataset(load_tables=True)
-        self.assert_has_table_properties(True)
-        self.load_dataset(load_tables=False)
-        self.assert_has_table_properties(True)
+        It also loads the dataset another two times from cache,
+        with changing ``load_tables``
+        arguments,
+        which should always result
+        in existing table related properties,
+        as a cache stord first with ``load_tables=False``,
+        should be updated when loading again with ``load_tables=True``.
 
-    def test_load_tables_second(self):
-        r"""Load and dataset without table related properties.
-
-        This instantiates the dataset
-        the first time with ``load_tables=False``,
-        which should not cache table related properties.
-        When loading the dataset
-        afterwards with ``load_tables=True``,
-        the table related properties
-        should then be loaded.
+        Args:
+            load_tables_first: if ``True``,
+                it calls ``audbcards.Dataset``
+                with ``load_tables=True``
+                during it first call
+                and with ``load_tables=False``
+                during its second call;
+                and vice versa if ``False``
 
         """
-        self.load_dataset(load_tables=False)
-        self.assert_has_table_properties(False)
-        self.load_dataset(load_tables=True)
+        self.load_dataset(load_tables=load_tables_first)
+        self.assert_has_table_properties(load_tables_first)
+        self.load_dataset(load_tables=not load_tables_first)
+        self.assert_has_table_properties(True)
+        self.load_dataset(load_tables=load_tables_first)
         self.assert_has_table_properties(True)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -457,7 +457,7 @@ class TestDatasetLoadTables:
 
     @classmethod
     @pytest.fixture(autouse=True)
-    def setup(cls, cache, medium_db):
+    def prepare(cls, cache, medium_db):
         r"""Provide test class with cache, database name and database version.
 
         Args:


### PR DESCRIPTION
Closes #30.

Adds the property `audbcards.Dataset.segments` which returns the number of segments inside a dataset,
and `audbcards.Dataset.segment_durations` which returns the durations of all segments.

The new properties deviate from all others, as they require to download all segmented tables of a dataset. As this can take a very long time or fail if your memory is not sufficient, the pull request also provides the ability to skip downloading the tables when instantiating `audbcards.Dataset` by setting its new `load_tables` argument to `False`.
If `load_tables` is `False` it will then only load the tables when you call `audbcards.Dataset.segments` or `audbcards.Dataset.segment_durations`.

When you cached the first version of a dataset with `load_tables=False`, and then instantiate another instance with `load_tables=True`, it will call `audbcards.Dataset.segments` and `audbcards.Dataset.segment_durations`, and update the stored cache, so the properties are directly loaded from cache the next time. A nie side effect is, that this will update existing caches automatically to store the new properties.

Under the hood the pull request introduces the private cached property `audbcards.Dataset._segments`, and modifies `audbcards.Dataset._cached_properties()` to return only non-private properties. This affects `audbcards.Dataset._scheme_table_columns`, which is no longer cached, but this is also not needed as all its derived properties are cached already.

<details><summary>Example with a dataset from our internal server.</summary>

```python
import tempfile
import time

import audbcards


t0 = time.time()
with tempfile.TemporaryDirectory() as tmpdir:
    ds = audbcards.Dataset("levantine-arabic-qt", "1.2.1", cache_root=tmpdir, load_tables=False)
t = time.time() - t0
print(f"Caching dataset without tables: {t:.2f} s")

t0 = time.time()
ds.segments
t = time.time() - t0
print(f"Collect number of segments: {t:.5f} s")

t0 = time.time()
ds.segments
t = time.time() - t0
print(f"Collect number of segments: {t:.5f} s")

t0 = time.time()
with tempfile.TemporaryDirectory() as tmpdir:
    ds = audbcards.Dataset("levantine-arabic-qt", "1.2.1", cache_root=tmpdir, load_tables=True)
t = time.time() - t0
print(f"Update cache with storing table related properties: {t:.2f} s")

t0 = time.time()
ds.segments
t = time.time() - t0
print(f"Collect number of segments: {t:.5f} s")
```

This returns

```
Caching dataset without tables: 1.23 s
Collect number of segments: 2.36247 s
Collect number of segments: 0.00003 s
Update cache with storing table related properties: 5.03 s
Collect number of segments: 0.00002 s
```

---

</details>


![image](https://github.com/audeering/audbcards/assets/173624/304ac89d-ad24-40bd-9d55-154dd0b70620)

---

We also add the `load_tables` argument to `audbcards.Dataset`.

![image](https://github.com/user-attachments/assets/9b1d8615-9e1d-46e8-926a-d317adc21849)

