### PR TITLE
TST: allow to provide databases as test parameter

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import shutil
+import typing
 
 import jinja2
 import matplotlib.pyplot as plt
@@ -48,14 +49,15 @@ class Datacard(object):
 
         # Add audio player for example file
         dataset['example'] = self.example
-        dataset['player'] = self.player(dataset['example'])
+        if dataset['example'] is not None:
+            dataset['player'] = self.player(dataset['example'])
 
         content = template.render(dataset)
 
         return content
 
     @property
-    def example(self) -> str:
+    def example(self) -> typing.Optional[str]:
         r"""Select example media file.
 
         This select a media file
@@ -75,6 +77,8 @@ class Datacard(object):
         selected_duration = np.median(
             [d for d in durations if d >= min_dur and d <= max_dur]
         )
+        if np.isnan(selected_duration):
+            return None
         # Get index for duration closest to selected duration
         # see https://stackoverflow.com/a/9706105
         # durations.index(selected_duration)
@@ -94,7 +98,7 @@ class Datacard(object):
                 verbose=False,
             )
         except:  # noqa: E722
-            media = ''
+            media = None
         return media
 
     def player(self, file: str) -> str:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -356,6 +356,9 @@ class Dataset:
         """
         schemes = self.header.schemes
 
+        if len(schemes) == 0:
+            return []
+
         columns = ['ID', 'Dtype']
 
         if len(schemes) > 0:

--- a/audbcards/core/templates/datacard_description.j2
+++ b/audbcards/core/templates/datacard_description.j2
@@ -1,6 +1,6 @@
 
 
-{% if description is defined and description|length > 0 %}
+{% if description is not none and description|length > 0 %}
 Description
 {% for n in range("Description"|length) %}^{% endfor %}
 

--- a/audbcards/core/templates/datacard_example.j2
+++ b/audbcards/core/templates/datacard_example.j2
@@ -1,5 +1,5 @@
+{% if example is not none %}
 
-{% if example|length > 0 %}
 Example
 {% for n in range("Example"|length) %}^{% endfor %}
 

--- a/audbcards/core/templates/datacard_header.j2
+++ b/audbcards/core/templates/datacard_header.j2
@@ -3,8 +3,8 @@
 {{ name }}
 {% for n in range(name|length) %}-{% endfor %}
 
+{% if author is not none %}
 
-{% if author is defined %}
 Created by {{ author }}
 {% endif %}
 

--- a/audbcards/core/templates/datacard_schemes.j2
+++ b/audbcards/core/templates/datacard_schemes.j2
@@ -1,4 +1,5 @@
 
+{% if schemes_table is defined and schemes_table|length > 1 %}
 Schemes
 ^^^^^^^
 
@@ -8,3 +9,4 @@ Schemes
 {% for row in schemes_table %}
     "{{ row|join('", "') }}"
 {% endfor %}
+{% endif %}

--- a/audbcards/core/templates/datacard_tables.j2
+++ b/audbcards/core/templates/datacard_tables.j2
@@ -1,4 +1,5 @@
 
+{% if tables_table is defined and tables_table|length > 1 %}
 Tables
 ^^^^^^
 
@@ -9,3 +10,4 @@ Tables
 {% for row in tables_table %}
     "{{ row|join('", "') }}"
 {% endfor %}
+{% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import typing
 
 import numpy as np
 import pandas as pd
@@ -10,10 +11,7 @@ import audformat
 import audiofile
 
 
-pytest.NAME = 'db'
-pytest.REPOSITORY = None
 pytest.VERSION = '1.0.0'
-
 pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
 pytest.TEMPLATE_DIR = audeer.mkdir(
     os.path.join(
@@ -30,7 +28,83 @@ def cache(tmpdir, scope='function'):
 
 
 @pytest.fixture
-def publish_db(tmpdir, scope='session', autouse=True):
+def audb_cache(tmpdir, scope='session', autouse=True):
+    """Provide a local audb cache only visible inside the tests."""
+    cache = audeer.mkdir(audeer.path(tmpdir, 'audb-cache'))
+    audb.config.CACHE_ROOT = cache
+    audb.config.SHARED_CACHE = cache
+
+
+@pytest.fixture
+def repository(tmpdir, scope='session'):
+    """Provide audb repository only visible inside the tests."""
+    host = audeer.mkdir(audeer.path(tmpdir, 'repo'))
+    repository = audb.Repository(
+        name='data-local',
+        host=host,
+        backend='file-system',
+    )
+    audb.config.REPOSITORIES = [repository]
+    return repository
+
+
+@pytest.fixture
+def minimal_db(
+        tmpdir,
+        repository,
+        scope='session',
+        autouse=True,
+):
+    r"""Publish and load a minimal database.
+
+    The name of the database will be ``minimal-db``.
+
+    The database has no schemes
+    and a single filewise table.
+
+    Further it contains a single file
+    with a length of 0.01 s.
+
+
+    """
+    name = 'minimal_db'
+
+    db_path = audeer.mkdir(audeer.path(tmpdir, name))
+
+    db = audformat.Database(
+        name=name,
+        source='https://github.com/audeering/audbcards',
+        usage='unrestricted',
+        expires=None,
+        languages=[],
+        description='Minimal database.',
+        author='H Wierstorf, C Geng, B E Abrougui',
+        license=audformat.define.License.CC0_1_0,
+    )
+
+    # Table 'files'
+    index = audformat.filewise_index(['f0.wav'])
+    db['files'] = audformat.Table(index)
+    db['files']['speaker'] = audformat.Column()
+    db['files']['speaker'].set([0])
+
+    # Create audio files and store database
+    durations = [.1]  # s
+    create_audio_files(db, db_path, durations)
+    db.save(db_path)
+
+    # Publish and load database
+    audb.publish(db_path, pytest.VERSION, repository)
+    return audb.load(name, version=pytest.VERSION, verbose=False)
+
+
+@pytest.fixture
+def medium_db(
+        tmpdir,
+        repository,
+        scope='session',
+        autouse=True,
+):
     r"""Publish a test database.
 
     The database will use ``pytest.NAME`` as name
@@ -42,14 +116,12 @@ def publish_db(tmpdir, scope='session', autouse=True):
     the database was published to.
 
     """
-    cache = audeer.mkdir(audeer.path(tmpdir, 'audb-cache'))
-    audb.config.CACHE_ROOT = cache
-    audb.config.SHARED_CACHE = cache
+    name = 'medium_db'
 
-    db_path = audeer.mkdir(audeer.path(tmpdir, pytest.NAME))
+    db_path = audeer.mkdir(audeer.path(tmpdir, name))
 
     db = audformat.Database(
-        name=pytest.NAME,
+        name=name,
         source='https://github.com/audeering/audbcards',
         usage='unrestricted',
         expires=None,
@@ -111,37 +183,13 @@ def publish_db(tmpdir, scope='session', autouse=True):
     db['segments']['emotion'].set(['neutral', 'neutral', 'happy', 'angry'])
 
     # Create audio files and store database
-    np.random.seed(1)
-    sampling_rate = 8000
     durations = [1, 301]
-    for i, file in enumerate(list(db['files'].index)):
-        path = audeer.path(db_path, file)
-        audeer.mkdir(os.path.dirname(path))
-        signal = np.random.normal(0, .1, (1, durations[i] * sampling_rate))
-        audiofile.write(path, signal, sampling_rate, normalize=True)
+    create_audio_files(db, db_path, durations)
     db.save(db_path)
 
-    # Publish database
-    host = audeer.mkdir(audeer.path(tmpdir, 'repo'))
-    repository = audb.Repository(
-        name='data-local',
-        host=host,
-        backend='file-system',
-    )
-    audb.config.REPOSITORIES = [repository]
+    # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
-
-    # Make repository variable available in tests
-    pytest.REPOSITORY = repository
-
-
-@pytest.fixture
-def db(publish_db, scope='function'):
-    return audb.load(
-        pytest.NAME,
-        version=pytest.VERSION,
-        verbose=False,
-    )
+    return audb.load(name, version=pytest.VERSION, verbose=False)
 
 
 @pytest.fixture
@@ -153,3 +201,21 @@ def default_template(scope='function'):
         template_truth = file.read().rstrip()
 
     return template_truth
+
+
+def create_audio_files(
+        db: audformat.Database,
+        db_path: str,
+        durations: typing.Sequence[float],
+        *,
+        sampling_rate: int = 8000,
+        seed: int = 1,
+):
+    r"""Create audio files with given durations."""
+    np.random.seed(seed)
+    for n, file in enumerate(list(db['files'].index)):
+        path = audeer.path(db_path, file)
+        audeer.mkdir(os.path.dirname(path))
+        samples = int(durations[n] * sampling_rate)
+        signal = np.random.normal(0, .1, (1, samples))
+        audiofile.write(path, signal, sampling_rate, normalize=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,13 @@ pytest.TEMPLATE_DIR = audeer.mkdir(
 
 @pytest.fixture
 def cache(tmpdir, scope='function'):
+    """Local cache folder."""
     return audeer.mkdir(audeer.path(tmpdir, 'cache'))
 
 
 @pytest.fixture
 def audb_cache(tmpdir, scope='session', autouse=True):
-    """Provide a local audb cache only visible inside the tests."""
+    """Local audb cache folder."""
     cache = audeer.mkdir(audeer.path(tmpdir, 'audb-cache'))
     audb.config.CACHE_ROOT = cache
     audb.config.SHARED_CACHE = cache
@@ -37,7 +38,7 @@ def audb_cache(tmpdir, scope='session', autouse=True):
 
 @pytest.fixture
 def repository(tmpdir, scope='session'):
-    """Provide audb repository only visible inside the tests."""
+    """Local audb repository only visible inside the tests."""
     host = audeer.mkdir(audeer.path(tmpdir, 'repo'))
     repository = audb.Repository(
         name='data-local',
@@ -57,14 +58,13 @@ def minimal_db(
 ):
     r"""Publish and load a minimal database.
 
-    The name of the database will be ``minimal-db``.
+    The name of the database will be ``minimal_db``.
 
     The database has no schemes
     and a single filewise table.
 
     Further it contains a single file
     with a length of 0.01 s.
-
 
     """
     name = 'minimal_db'
@@ -105,15 +105,14 @@ def medium_db(
         scope='session',
         autouse=True,
 ):
-    r"""Publish a test database.
+    r"""Publish and load a medium test database.
 
-    The database will use ``pytest.NAME`` as name
-    and ``pytest.VERSION`` as version.
-    It will be published to a file-system repository
-    in a tmp folder.
-    ``audb.config.REPOSITORIES`` will be adjusted
-    to point to the repository
-    the database was published to.
+    The name of the database will be ``medium_db``.
+
+    The database contains
+    several schemes,
+    filewise, segmented, and misc tables,
+    and audio files that are suited as an example.
 
     """
     name = 'medium_db'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def medium_db(
         usage='unrestricted',
         expires=None,
         languages=['eng', 'de'],
-        description='Example database.',
+        description='Medium database.',
         author='H Wierstorf, C Geng, B E Abrougui',
         organization='audEERING',
         license=audformat.define.License.CC0_1_0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,34 @@ def repository(tmpdir, scope='session'):
 
 
 @pytest.fixture
+def bare_db(
+        tmpdir,
+        repository,
+        scope='session',
+        autouse=True,
+):
+    r"""Publish and load a bare database.
+
+    The name of the database will be ``bare_db``.
+
+    The database has no schemes,
+    no table,
+    and no media files.
+
+    """
+    name = 'bare_db'
+
+    db_path = audeer.mkdir(audeer.path(tmpdir, name))
+
+    db = audformat.Database(name=name)
+    db.save(db_path)
+
+    # Publish and load database
+    audb.publish(db_path, pytest.VERSION, repository)
+    return audb.load(name, version=pytest.VERSION, verbose=False)
+
+
+@pytest.fixture
 def minimal_db(
         tmpdir,
         repository,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,17 +192,6 @@ def medium_db(
     return audb.load(name, version=pytest.VERSION, verbose=False)
 
 
-@pytest.fixture
-def default_template(scope='function'):
-
-    fpath = os.path.join(pytest.TEMPLATE_DIR, 'default.rst')
-
-    with open(fpath, 'r') as file:
-        template_truth = file.read().rstrip()
-
-    return template_truth
-
-
 def create_audio_files(
         db: audformat.Database,
         db_path: str,

--- a/tests/test_data/rendered_templates/bare_db.rst
+++ b/tests/test_data/rendered_templates/bare_db.rst
@@ -1,0 +1,20 @@
+.. _bare_db:
+
+bare_db
+-------
+
+============= ======================
+version       1.0.0
+license       Unknown
+source        
+usage         unrestricted
+languages     
+format        
+channel       
+sampling rate 
+bit depth     
+duration      0 days 00:00:00
+files         0
+repository    `data-local <.../data-local/bare_db>`__
+published     2023-04-05 by author
+============= ======================

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -1,7 +1,7 @@
-.. _db:
+.. _medium_db:
 
-db
---
+medium_db
+---------
 
 Created by H Wierstorf, C Geng, B E Abrougui
 
@@ -31,11 +31,11 @@ Example
 
 :file:`data/f0.wav`
 
-.. image:: ../db.png
+.. image:: ../medium_db.png
 
 .. raw:: html
 
-    <p><audio controls src="db/data/f0.wav"></audio></p>
+    <p><audio controls src="medium_db/data/f0.wav"></audio></p>
 
 Tables
 ^^^^^^

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -24,7 +24,7 @@ published     2023-04-05 by author
 Description
 ^^^^^^^^^^^
 
-Example database.
+Medium database.
 
 Example
 ^^^^^^^

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -17,7 +17,7 @@ sampling rate 8000
 bit depth     16
 duration      0 days 00:05:02
 files         2
-repository    `data-local <.../data-local/db>`__
+repository    `data-local <.../data-local/medium_db>`__
 published     2023-04-05 by author
 ============= ======================
 

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -17,7 +17,7 @@ sampling rate 8000
 bit depth     16
 duration      0 days 00:00:00.100000
 files         1
-repository    `data-local <.../data-local/db_minimal>`__
+repository    `data-local <.../data-local/minimal_db>`__
 published     2023-04-05 by author
 ============= ======================
 

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -1,0 +1,37 @@
+.. _minimal_db:
+
+minimal_db
+----------
+
+Created by H Wierstorf, C Geng, B E Abrougui
+
+============= ======================
+version       1.0.0
+license       `CC0-1.0 <https://creativecommons.org/publicdomain/zero/1.0/>`__
+source        https://github.com/audeering/audbcards
+usage         unrestricted
+languages     
+format        wav
+channel       1
+sampling rate 8000
+bit depth     16
+duration      0 days 00:00:00.100000
+files         1
+repository    `data-local <.../data-local/db_minimal>`__
+published     2023-04-05 by author
+============= ======================
+
+Description
+^^^^^^^^^^^
+
+Minimal database.
+
+Tables
+^^^^^^
+
+.. csv-table::
+    :header-rows: 1
+    :widths: 20, 10, 70
+
+    "ID", "Type", "Columns"
+    "files", "filewise", "speaker"

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -24,6 +24,32 @@ BUILD = audeer.path('..', 'build', 'html')
         'medium_db',
     ],
 )
+def test_datacard(db, cache, request):
+    """Test datacard creation from jinja2 templates."""
+    db = request.getfixturevalue(db)
+    dataset = audbcards.Dataset(db.name, pytest.VERSION, cache)
+    dc = audbcards.Datacard(dataset)
+    content = dc._render_template()
+    content = content.rstrip()
+    expected_content = load_rendered_template(db.name)
+
+    # Remove lines that depend on author/local machine
+    for pattern in [
+            re.compile('^published.*$', flags=(re.MULTILINE)),
+            re.compile('^repository.*$', flags=(re.MULTILINE)),
+    ]:
+        content = re.sub(pattern, '', content)
+        expected_content = re.sub(pattern, '', expected_content)
+
+    assert content == expected_content
+
+
+@pytest.mark.parametrize(
+    'db',
+    [
+        'medium_db',
+    ],
+)
 def test_datacard_example(db, cache, request):
     r"""Test Datacard.example.
 
@@ -49,40 +75,6 @@ def test_datacard_example(db, cache, request):
     ).replace(os.sep, posixpath.sep)
     expected_example = '/'.join(expected_example.split('/')[-2:])
     assert datacard.example == expected_example
-
-
-@pytest.mark.parametrize(
-    'db',
-    [
-        'medium_db',
-    ],
-)
-def test_datacard_lines_similar(db, default_template, cache, request):
-    """Create datacard using jinja2 via Dataset and Datacard.
-
-    The assertions for exact identity are currently too strict.
-    Therefore this uses text similarities as obtained from
-    the difflib builtins. These are based on
-
-    - average (or rather median and mean) similarities per line
-    - percentage of lines differing between original and rendered
-
-    """
-    db = request.getfixturevalue(db)
-    dataset = audbcards.Dataset(db.name, pytest.VERSION, cache)
-    dc = audbcards.Datacard(dataset)
-    content = dc._render_template()
-    content = content.rstrip()
-
-    # Remove lines that depend on author/local machine
-    for pattern in [
-            re.compile('^published.*$', flags=(re.MULTILINE)),
-            re.compile('^repository.*$', flags=(re.MULTILINE)),
-    ]:
-        content = re.sub(pattern, '', content)
-        default_template = re.sub(pattern, '', default_template)
-
-    assert content == default_template
 
 
 @pytest.mark.parametrize(
@@ -144,3 +136,11 @@ def test_create_datasets_page(db):
     r"""Test the creation of an RST file with an datasets overview table."""
     datasets = [audbcards.Dataset(pytest.NAME, pytest.VERSION)] * 4
     create_datasets_page(datasets, ofbase="datasets_page")
+
+
+def load_rendered_template(name: str) -> str:
+    r"""Load the expected rendered RST file."""
+    fpath = os.path.join(pytest.TEMPLATE_DIR, f'{name}.rst')
+    with open(fpath, 'r') as file:
+        rendered_rst = file.read().rstrip()
+    return rendered_rst

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -18,14 +18,21 @@ from audbcards.core.utils import set_plot_margins
 BUILD = audeer.path('..', 'build', 'html')
 
 
-def test_datacard_example(db, cache):
+@pytest.mark.parametrize(
+    'db',
+    [
+        'medium_db',
+    ],
+)
+def test_datacard_example(db, cache, request):
     r"""Test Datacard.example.
 
     It checks that the desired audio file
     is selected as example.
 
     """
-    dataset = audbcards.Dataset(pytest.NAME, pytest.VERSION, cache)
+    db = request.getfixturevalue(db)
+    dataset = audbcards.Dataset(db.name, pytest.VERSION, cache)
     datacard = audbcards.Datacard(dataset)
 
     # Relative path to audio file from database
@@ -44,7 +51,13 @@ def test_datacard_example(db, cache):
     assert datacard.example == expected_example
 
 
-def test_datacard_lines_similar(db, default_template, cache):
+@pytest.mark.parametrize(
+    'db',
+    [
+        'medium_db',
+    ],
+)
+def test_datacard_lines_similar(db, default_template, cache, request):
     """Create datacard using jinja2 via Dataset and Datacard.
 
     The assertions for exact identity are currently too strict.
@@ -55,7 +68,8 @@ def test_datacard_lines_similar(db, default_template, cache):
     - percentage of lines differing between original and rendered
 
     """
-    dataset = audbcards.Dataset(pytest.NAME, pytest.VERSION, cache)
+    db = request.getfixturevalue(db)
+    dataset = audbcards.Dataset(db.name, pytest.VERSION, cache)
     dc = audbcards.Datacard(dataset)
     content = dc._render_template()
     content = content.rstrip()
@@ -71,7 +85,13 @@ def test_datacard_lines_similar(db, default_template, cache):
     assert content == default_template
 
 
-def test_datacard_player(db, cache):
+@pytest.mark.parametrize(
+    'db',
+    [
+        'medium_db',
+    ],
+)
+def test_datacard_player(db, cache, request):
     r"""Test the Datacard.player.
 
     It checks if the desired waveplot PNG file is created,
@@ -80,7 +100,8 @@ def test_datacard_player(db, cache):
     to include the player is returned.
 
     """
-    dataset = audbcards.Dataset(pytest.NAME, pytest.VERSION, cache)
+    db = request.getfixturevalue(db)
+    dataset = audbcards.Dataset(db.name, pytest.VERSION, cache)
     datacard = audbcards.Datacard(dataset)
 
     player_str = datacard.player(datacard.example)

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -21,6 +21,7 @@ BUILD = audeer.path('..', 'build', 'html')
 @pytest.mark.parametrize(
     'db',
     [
+        'bare_db',
         'minimal_db',
         'medium_db',
     ],

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -132,9 +132,16 @@ def test_datacard_player(db, cache, request):
     assert expected_player_str == player_str
 
 
-def test_create_datasets_page(db):
+@pytest.mark.parametrize(
+    'dbs',
+    [
+        ['minimal_db', 'medium_db'],
+    ],
+)
+def test_create_datasets_page(dbs, request):
     r"""Test the creation of an RST file with an datasets overview table."""
-    datasets = [audbcards.Dataset(pytest.NAME, pytest.VERSION)] * 4
+    dbs = [request.getfixturevalue(db) for db in dbs]
+    datasets = [audbcards.Dataset(db.name, pytest.VERSION) for db in dbs]
     create_datasets_page(datasets, ofbase="datasets_page")
 
 

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -21,6 +21,7 @@ BUILD = audeer.path('..', 'build', 'html')
 @pytest.mark.parametrize(
     'db',
     [
+        'minimal_db',
         'medium_db',
     ],
 )
@@ -28,8 +29,8 @@ def test_datacard(db, cache, request):
     """Test datacard creation from jinja2 templates."""
     db = request.getfixturevalue(db)
     dataset = audbcards.Dataset(db.name, pytest.VERSION, cache)
-    dc = audbcards.Datacard(dataset)
-    content = dc._render_template()
+    datacard = audbcards.Datacard(dataset)
+    content = datacard._render_template()
     content = content.rstrip()
     expected_content = load_rendered_template(db.name)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -16,7 +16,7 @@ import audbcards
     ],
 )
 def test_dataset(audb_cache, tmpdir, repository, db, request):
-
+    r"""Test audbcards.Dataset object and all its properties."""
     db = request.getfixturevalue(db)
 
     dataset_cache = audeer.mkdir(audeer.path(tmpdir, 'cache'))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,28 +9,37 @@ import audiofile
 import audbcards
 
 
-def test_dataset(cache, tmpdir, db):
+@pytest.mark.parametrize(
+    'db',
+    [
+        'medium_db',
+    ],
+)
+def test_dataset(audb_cache, tmpdir, repository, db, request):
+
+    db = request.getfixturevalue(db)
+
     dataset_cache = audeer.mkdir(audeer.path(tmpdir, 'cache'))
     dataset = audbcards.Dataset(
-        pytest.NAME,
+        db.name,
         pytest.VERSION,
         cache_root=dataset_cache,
     )
 
     # __init__
-    assert dataset.name == pytest.NAME
+    assert dataset.name == db.name
     assert dataset.version == pytest.VERSION
-    assert dataset._repository == pytest.REPOSITORY
+    assert dataset._repository == repository
     expected_header = audb.info.header(
-        pytest.NAME,
+        db.name,
         version=pytest.VERSION,
-        cache_root=cache,
+        cache_root=audb_cache,
     )
     assert str(dataset.header) == str(expected_header)
     expected_deps = audb.dependencies(
-        pytest.NAME,
+        db.name,
         version=pytest.VERSION,
-        cache_root=cache,
+        cache_root=audb_cache,
     )
     expected_df = expected_deps()
     pd.testing.assert_frame_equal(dataset.deps(), expected_df)
@@ -106,8 +115,7 @@ def test_dataset(cache, tmpdir, db):
     # publication: skipped for now
 
     # repository
-    expected_repository = pytest.REPOSITORY.name
-    assert dataset.repository == expected_repository
+    assert dataset.repository == repository.name
 
     # repository_link : skipped for now
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -3,25 +3,20 @@ import pytest
 import audb
 
 
-def test_db_fixture(db):
-
-    assert db.name == pytest.NAME
-
+@pytest.mark.parametrize(
+    'db',
+    [
+        'minimal_db',
+        'medium_db',
+    ],
+)
+def test_db_fixture(repository, db, request):
+    r"""Check if fixtures for publishing databases work as expected."""
+    db = request.getfixturevalue(db)
     db_loaded = audb.load(
-        pytest.NAME,
+        db.name,
         version=pytest.VERSION,
         verbose=False,
     )
     assert db_loaded == db
-    assert audb.repository(pytest.NAME, pytest.VERSION) == pytest.REPOSITORY
-
-
-def test_publish_db_fixture():
-
-    db_loaded = audb.load(
-        pytest.NAME,
-        version=pytest.VERSION,
-        verbose=False,
-    )
-    assert db_loaded.name == pytest.NAME
-    assert audb.repository(pytest.NAME, pytest.VERSION) == pytest.REPOSITORY
+    assert audb.repository(db.name, pytest.VERSION) == repository


### PR DESCRIPTION
Closes #32
Closes #34
Closes #35 
Alternative implementation to https://github.com/audeering/audbcards/issues/33 (it copies the implementation, but provides other tests).

This introduces the possibility to publish several databases and use those as parameters for other tests.
Currently, I just added a second minimal database, and use it to test my solutions for #32 and #34.

Handling of #32:

* **code**: `audbcards.Dataset._scheme_table_columns` returns `[]` if no schemes are provided
* **template**: `audbcards/core/templates/datacard_schemes.j2` is extended to not include a scheme table if not available 
* **test**: the fixture `minimal_db` creates a databases without any schemes

Handling of #34:

* **code**: `audbcards.Dataset.example` returns `None` instead of `''` if no suitable example file can be detected. Inside `audbcards.Datacard._render_template()` `audbcards.Datacard.player` is not called if `audbcards.Dataset.example` is `None`
* **template**: `audbcards/core/templates/datacard_example.j2` is extended to not include an example if `audbcards.Dataset.example` is `None`
* **test**: the fixture `minimal_db` creates a single audio file, which is too short to be used as an example