### PR TITLE
Remove audbcards.Datacard._trim_trailing_whitespace()

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -39,10 +39,6 @@ class Datacard(object):
         t_dir = os.path.join(os.path.dirname(__file__), 'templates')
         environment = jinja2.Environment(loader=jinja2.FileSystemLoader(t_dir),
                                          trim_blocks=True)
-        # Provide Jinja filter access to Python build-ins/functions
-        environment.filters.update(
-            zip=zip,
-        )
         template = environment.get_template("datacard.j2")
 
         # === Add/change content of Dataset class

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -42,7 +42,6 @@ class Datacard(object):
         # Provide Jinja filter access to Python build-ins/functions
         environment.filters.update(
             zip=zip,
-            tw=self._trim_trailing_whitespace,
         )
         template = environment.get_template("datacard.j2")
 
@@ -58,22 +57,6 @@ class Datacard(object):
         content = template.render(dataset)
 
         return content
-
-    @staticmethod
-    def _trim_trailing_whitespace(x: list):
-        """J2 filter to get rid of trailing empty table entries within a row.
-
-        Trims last entry if present.
-
-        Args:
-            x: untrimmed single scheme table row
-        Returns:
-            trimmed single scheme table row
-        """
-        if x[-1] == '':
-            x.pop()
-
-        return x
 
     @property
     def example(self) -> str:

--- a/audbcards/core/templates/datacard_schemes.j2
+++ b/audbcards/core/templates/datacard_schemes.j2
@@ -6,6 +6,5 @@ Schemes
     :header-rows: 1
 
 {% for row in schemes_table %}
-  {% set row_trimmed = row|tw %}
-  "{{ row_trimmed|join('", "') }}"
+    "{{ row|join('", "') }}"
 {% endfor %}

--- a/tests/test_data/rendered_templates/default.rst
+++ b/tests/test_data/rendered_templates/default.rst
@@ -56,7 +56,7 @@ Schemes
     :header-rows: 1
 
     "ID", "Dtype", "Min", "Labels", "Mappings"
-    "age", "int", "0", ""
-    "emotion", "str", "", "angry, happy, neutral"
-    "gender", "str", "", "female, male"
+    "age", "int", "0", "", ""
+    "emotion", "str", "", "angry, happy, neutral", ""
+    "gender", "str", "", "female, male", ""
     "speaker", "int", "", "0, 1", "age, gender"


### PR DESCRIPTION
Closes #21 

This removes `audbcards.Datacard._trim_trailing_whitespace()` as it is not required.