### PR TITLE
Add audbcards.Dataset.iso_languages

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -178,7 +178,7 @@ class Dataset:
 
             iso_languages.append(iso_language)
 
-        return list(set(iso_languages))
+        return sorted(list(set(iso_languages)))
 
     @property
     def license(self) -> str:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -153,7 +153,7 @@ class Dataset:
 
     @property
     def iso_languages(self) -> typing.List[str]:
-        r"""Languages of the database."""
+        r"""Languages of the database as ISO 639-3 if possible."""
         return self._map_iso_languages(self.languages)
 
     @staticmethod

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -158,7 +158,7 @@ class Dataset:
 
     @staticmethod
     def _map_iso_languages(languages : typing.List[str]) -> typing.List[str]:
-        r"""calculate ISO languages for a list of languages.
+        r"""Calculate ISO languages for a list of languages.
 
         Args:
             languages: list of languages as given in the header languages

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -160,13 +160,14 @@ class Dataset:
     def _map_iso_languages(languages : typing.List[str]) -> typing.List[str]:
         r"""Calculate ISO languages for a list of languages.
 
+        Leaves languages intact if :func:`audformat.utils.map_language`
+        raises :exception:`ValueError`.
+        
         Args:
             languages: list of languages as given in the header languages
+            
         Returns:
             list of languages
-
-        Behavior: leaves languages intact if `audformat.utils.map_language`
-        raises ValueError
 
         """
         iso_languages = []

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -152,6 +152,35 @@ class Dataset:
         return self.header.languages
 
     @property
+    def iso_languages(self) -> typing.List[str]:
+        r"""Languages of the database."""
+        return self._map_iso_languages(self.languages)
+
+    @staticmethod
+    def _map_iso_languages(languages : typing.List[str]) -> typing.List[str]:
+        r"""calculate ISO languages for a list of languages.
+
+        Args:
+            languages: list of languages as given in the header languages
+        Returns:
+            list of languages
+
+        Behavior: leaves languages intact if `audformat.utils.map_language`
+        raises ValueError
+
+        """
+        iso_languages = []
+        for lang in languages:
+            try:
+                iso_language = audformat.utils.map_language(lang)
+            except ValueError:
+                iso_language = lang
+
+            iso_languages.append(iso_language)
+
+        return list(set(iso_languages))
+
+    @property
     def license(self) -> str:
         r"""License of dataset.
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -162,10 +162,10 @@ class Dataset:
 
         Leaves languages intact if :func:`audformat.utils.map_language`
         raises :exception:`ValueError`.
-        
+
         Args:
             languages: list of languages as given in the header languages
-            
+
         Returns:
             list of languages
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -222,7 +222,20 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
         )
     ]
 )
-def test_language_mappings(languages, iso_languages_expected):
-    """Test language mapping method."""
+def test_iso_language_mappings(languages, iso_languages_expected):
+    """Test ISO 639-3 language mapping method."""
     iso_languages_calculated = audbcards.Dataset._map_iso_languages(languages)
     assert iso_languages_calculated == sorted(iso_languages_expected)
+
+
+@pytest.mark.parametrize(
+    'dbs',
+    [
+        ['minimal_db', 'medium_db'],
+    ],
+)
+def test_iso_language_property(dbs, request):
+    """Test ISO 639-3 language mapping property."""
+    dbs = [request.getfixturevalue(db) for db in dbs]
+    datasets = [audbcards.Dataset(db.name, pytest.VERSION) for db in dbs]
+    _ = [dataset.iso_languages for dataset in datasets]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -179,3 +179,41 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     # version
     expected_version = pytest.VERSION
     assert dataset.version == expected_version
+
+
+@pytest.mark.parametrize(
+    "languages, iso_languages_expected",
+    [
+        (
+            ['greek', 'Greek', 'gr'], ['greek', 'Greek', 'gr']
+        ),
+        (
+            ['en', 'English', 'english', 'En'], ['eng']
+        ),
+        (
+            ['de', 'German', 'german', 'deu'], ['deu']
+        ),
+        (
+            ['Algerian Arabic', 'Egyptian Arabic', 'Libyan Arabic', 'Moroccan Arabic', 'North Levantine Arabic'], ['arz', 'ary', 'apc', 'ayl', 'arq']
+        ),
+        (
+            ['Algerian Arabic'], ['arq']
+        ),
+        (
+            ['Egyptian Arabic'], ['arz']
+        ),
+        (
+            ['Libyan Arabic'], ['ayl']
+        ),
+        (
+            ['North Levantine Arabic'], ['apc']
+        ),
+        (
+            ['Moroccan Arabic'], ['ary']
+        )
+    ]
+)
+def test_language_mappings(languages, iso_languages_expected):
+    """Test language mapping method."""
+    iso_languages_calculated = audbcards.Dataset._map_iso_languages(languages)
+    assert set(iso_languages_calculated) == set(iso_languages_expected)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -194,7 +194,16 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
             ['de', 'German', 'german', 'deu'], ['deu']
         ),
         (
-            ['Algerian Arabic', 'Egyptian Arabic', 'Libyan Arabic', 'Moroccan Arabic', 'North Levantine Arabic'], ['arz', 'ary', 'apc', 'ayl', 'arq']
+            ['Algerian Arabic',
+             'Egyptian Arabic',
+             'Libyan Arabic',
+             'Moroccan Arabic',
+             'North Levantine Arabic'],
+            ['arz',
+             'ary',
+             'apc',
+             'ayl',
+             'arq']
         ),
         (
             ['Algerian Arabic'], ['arq']

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -216,4 +216,4 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
 def test_language_mappings(languages, iso_languages_expected):
     """Test language mapping method."""
     iso_languages_calculated = audbcards.Dataset._map_iso_languages(languages)
-    assert set(iso_languages_calculated) == set(iso_languages_expected)
+    assert iso_languages_calculated == sorted(iso_languages_expected)


### PR DESCRIPTION
Closes #41 

Adds the property `audbcards.Dataset.iso_languages`, which returns the same as `audbcards.Dataset.languages` but tries to map the languages to the ISO 639-3 if possible.


