### PR TITLE
Make publication_date|owner independent of backend

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -1,15 +1,12 @@
-import datetime
 import os
-import random
 import typing
 
 import jinja2
 import pandas as pd
-import toml
 
 import audb
+import audbackend
 import audeer
-import audfactory
 import audformat
 
 from audbcards.core.utils import format_schemes
@@ -34,10 +31,7 @@ class Dataset:
             version: str,
             cache_root: str = './cache',
     ):
-        self._version = version
-        self._repository = audb.repository(name, version)
         self.cache_root = audeer.mkdir(audeer.path(cache_root))
-
         self.header = audb.info.header(
             name,
             version=version,
@@ -50,6 +44,16 @@ class Dataset:
             cache_root=self.cache_root,
             verbose=False,
         )
+
+        self._version = version
+        self._repository = audb.repository(name, version)
+        self._backend = audbackend.access(
+            name=self._repository.backend,
+            host=self._repository.host,
+            repository=self._repository.name,
+        )
+        if isinstance(self._backend, audbackend.Artifactory):
+            self._backend._use_legacy_file_structure()  # pragma: nocover
 
         # Clean up cache
         # by removing all other versions of the same dataset
@@ -185,51 +189,14 @@ class Dataset:
     @property
     def publication_date(self) -> str:
         r"""Date dataset was uploaded to repository."""
-        # NOTE: the following code can be replaced
-        # by audbackend.Backend.date()
-        # when audbackend 1.0.0 is released
-        url = (
-            f'{self._repository.host}/{self._repository.name}/{self.name}/'
-            f'db/{self._version}/db-{self._version}.zip'
-        )
-
-        if self._repository.backend == 'file-system':
-            ts = os.stat(url).st_ctime
-            date = datetime.datetime.utcfromtimestamp(ts)
-            date = date.strftime("%Y-%m-%d")
-        else:
-            path = audfactory.path(url)
-            stat = path.stat()
-            date = f'{stat.ctime:%Y-%m-%d}'
-
-        return date
+        path = self._backend.join('/', self.name, 'db.yaml')
+        return self._backend.date(path, self._version)
 
     @property
     def publication_owner(self) -> str:
         r"""User who uploaded dataset to repository."""
-        # NOTE: the following code can be replaced
-        # by audbackend.Backend.owner()
-        # when audbackend 1.0.0 is released
-        url = (
-            f'{self._repository.host}/{self._repository.name}/{self.name}/'
-            f'db/{self._version}/db-{self._version}.zip'
-        )
-
-        if self._repository.backend == 'file-system':
-            # NOTE: the following will
-            config = toml.load(audeer.path('pyproject.toml'))
-            authors = ', '.join(
-                author['name']
-                for author in config['project']['authors']
-            )
-            owners = authors.split(', ')
-            owner = random.choice(owners)
-        else:
-            path = audfactory.path(url)
-            stat = path.stat()
-            owner = f'{stat.created_by}'
-
-        return owner
+        path = self._backend.join('/', self.name, 'db.yaml')
+        return self._backend.owner(path, self._version)
 
     def properties(self):
         """Get list of properties of the object."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'audb >=1.5.2',
+    'audb >=1.6.0',
+    'audbackend >=1.0.1',
     'audplot >=1.4.6',
     'jinja2',
     'toml',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,9 +39,11 @@ def audb_cache(tmpdir, scope='session', autouse=True):
 @pytest.fixture
 def repository(tmpdir, scope='session'):
     """Local audb repository only visible inside the tests."""
+    name = 'data-local'
     host = audeer.mkdir(audeer.path(tmpdir, 'repo'))
+    audeer.mkdir(audeer.path(host, name))
     repository = audb.Repository(
-        name='data-local',
+        name=name,
         host=host,
         backend='file-system',
     )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import audb
+import audbackend
 import audeer
 import audformat
 import audiofile
@@ -24,6 +25,11 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
         db.name,
         pytest.VERSION,
         cache_root=dataset_cache,
+    )
+    backend = audbackend.access(
+        name=repository.backend,
+        host=repository.host,
+        repository=repository.name,
     )
 
     # __init__
@@ -119,7 +125,19 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
         expected_license_link = db.license_url
     assert dataset.license_link == expected_license_link
 
-    # publication: skipped for now
+    # publication_date:
+    expected_publication_date = backend.date(
+        backend.join('/', db.name, 'db.yaml'),
+        pytest.VERSION,
+    )
+    assert dataset.publication_date == expected_publication_date
+
+    # publication_owner
+    expected_publication_owner = backend.owner(
+        backend.join('/', db.name, 'db.yaml'),
+        pytest.VERSION,
+    )
+    assert dataset.publication_owner == expected_publication_owner
 
     # repository
     assert dataset.repository == repository.name


### PR DESCRIPTION
Closes #4 

This switches to use `audbackend>=1.0.1` which brings the two new backend independent methods `audbackend.Backend.date()` and `audbackend.Backend.owner()` which we now use inside the properties`audbcards.Dataset.publication_date` and `audbcards.Dataset.publication_owner`.

As we need a file on the backend to extract the information, I decided to use the database header file `db.yaml`