### PR TITLE
Require pandas>=2.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
             python-version: '3.9'
-            tasks: tests
-          - os: ubuntu-latest
-            python-version: '3.10'
             tasks: tests
 
     steps:

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -71,11 +71,14 @@ class Datacard(object):
         min_dur = 0.5
         max_dur = 300  # 5 min
         durations = self._dataset.file_durations
-        selected_duration = np.median(
-            [d for d in durations if d >= min_dur and d <= max_dur]
-        )
-        if np.isnan(selected_duration):
+        selected_durations = [
+            d for d in durations
+            if d >= min_dur and d <= max_dur
+        ]
+        if len(selected_durations) == 0:
             return None
+        selected_duration = np.median(selected_durations)
+
         # Get index for duration closest to selected duration
         # see https://stackoverflow.com/a/9706105
         # durations.index(selected_duration)

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -290,7 +290,7 @@ class Dataset:
 
         cols = self._scheme_table_columns
         data = pd.DataFrame.from_dict(dataset_schemes)[cols]
-        filter = data.applymap(lambda d: d == [])
+        filter = data.map(lambda d: d == [])
         data.mask(filter, other='', inplace=True)
         scheme_data = data.values.tolist()
         # Add column names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     'audbackend >=1.0.1',
     'audplot >=1.4.6',
     'jinja2',
+    'pandas >=2.1.0',
     'toml',
 ]
 # Get version dynamically from git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,11 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'audb >=1.6.0',
     'audbackend >=1.0.1',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,1 @@
-audeer >=1.20.2
 pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
+audeer >=1.20.2
 pytest


### PR DESCRIPTION
Closes #43 

In order to fix the deprecation warning mentioned in #43 the easiest solution is to replace the `applymap()` method with `map()`, which it was renamed to in `pandas` 2.1.0.
As `pandas` 2.1.0 requires Python >=3.9, I also adjusted `audbcards` accordingly as it is a new package and we have switched anyway to Python 3.10, so I see no to continue supporting Python 3.8 here.

This fixes deprecation warnings by:

* replacing `pandas.DataFrame.applymap()` by `pandas.DataFrame.map()`
* avoiding calculating `np.median` on an empty list