### PR TITLE
Specify Python package data in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,11 +187,11 @@ convention = 'google'
 
 # ----- setuptools --------------------------------------------------------
 #
-# Disable package data to only select the matching binary in setup.py
-[tool.setuptools]
-include-package-data = false
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
+
+[tool.setuptools.package-data]
+audbcards = ['core/templates/*']
 
 
 # ----- setuptools_scm ----------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-from setuptools import setup
-
-
-package_data = {"audbcards": ["core/templates/*"]}
-
-setup(package_data=package_data)


### PR DESCRIPTION
The package data was still defined in `setup.py`, which is not neccessary as long as we don't need platform depend code as for example in https://github.com/audeering/audresample/blob/main/setup.py