### PR TITLE
DOC: add API documentation

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -129,10 +129,10 @@ class Datacard(object):
 
     @property
     def file_duration_distribution(self) -> str:
-        r"""Min/max of files durations, and plotted distribution.
+        r"""Minimum and maximum of files durations, and plotted distribution.
 
         This generates a single line
-        containing the min/max values
+        containing the mininimum and maximum values
         of files durations.
 
         If :attr:`audbcards.Datacard.self.sphinx_src_dir` is set
@@ -141,7 +141,7 @@ class Datacard(object):
         in the sphinx source folder
         under ``<dataset-name>/<dataset-name>-file-durations.png``
         and displayed
-        between the min and max values.
+        between the minimum and maximum values.
 
         """
         min_ = 0

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -18,10 +18,14 @@ from audbcards.core.utils import set_plot_margins
 
 
 class Datacard(object):
-    r"""Datacard.
+    r"""Datacard of a dataset.
 
-    Datacard object to write a RST file
-    for a given dataset.
+    The datacard object
+    writes a RST file
+    for a given dataset,
+    which can then be used
+    to generate an HTML datacard page
+    using ``sphinx``.
 
     Args:
         dataset: dataset object

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -176,16 +176,20 @@ class Datacard(object):
 
     def player(
         self,
-        file: str,
+        file: str = None,
     ) -> str:
         r"""Create an audio player showing the waveform.
 
         Args:
             file: input audio file to be used in the player.
+                If ``None``,
                 :attr:`audbcards.Datacard.example_media`
-                is a good fit
+                is used
 
         """
+        if file is None:
+            file = self.example_media
+
         # use audb cache instead of dataset.cache_root
         media_src_dir = (
             f"{audb.default_cache_root()}/"

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -30,7 +30,7 @@ dohq_artifactory.GenericRepository.__setstate__ = _setstate
 
 
 class Dataset(object):
-    r"""Dataset.
+    r"""Dataset representation.
 
     Dataset object that represents a dataset
     that can be loaded with :func:`audb.load()`.

--- a/docs/api-src/audbcards.rst
+++ b/docs/api-src/audbcards.rst
@@ -1,0 +1,11 @@
+audbcards
+=========
+
+.. automodule:: audbcards
+
+.. autosummary::
+    :toctree:
+    :nosignatures:
+
+    Datacard
+    Dataset

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,16 @@ title = project
 # General -----------------------------------------------------------------
 master_doc = "index"
 source_suffix = ".rst"
-exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["build", "Thumbs.db", ".DS_Store", "api-src"]
 pygments_style = None
 extensions = [
     "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",  # support for Google-style docstrings
+    "sphinx_autodoc_typehints",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
     "sphinx_copybutton",
+    "sphinx_apipages",
     "audbcards.sphinx",
 ]
 # Disable Gitlab as we need to sign in

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@
 
     data-public
 
-.. Warning: then usage of genindex is a hack to get a TOC entry, see
+.. Warning: the usage of genindex is a hack to get a TOC entry, see
 .. https://stackoverflow.com/a/42310803. This might break the usage of sphinx if
 .. you want to create something different than HTML output.
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,16 @@
 
     data-public
 
+.. Warning: then usage of genindex is a hack to get a TOC entry, see
+.. https://stackoverflow.com/a/42310803. This might break the usage of sphinx if
+.. you want to create something different than HTML output.
+.. toctree::
+    :caption: API Documentation
+    :hidden:
+
+    api/audbcards
+    genindex
+
 .. toctree::
     :caption: Development
     :maxdepth: 2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
 audbcards
 sphinx
+sphinx-apipages
 sphinx-audeering-theme >=1.2.1
+sphinx-autodoc-typehints
 sphinx-copybutton

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -153,7 +153,7 @@ def test_datacard_player(tmpdir, db, cache, request):
 
     # Execute player
     # without specifying sphinx src and build dirs
-    player_str = datacard.player(datacard.example_media)
+    player_str = datacard.player()
     build_dir = audeer.mkdir(tmpdir, "build", "html")
     src_dir = audeer.mkdir(tmpdir, "docs")
     media_file = audeer.path(


### PR DESCRIPTION
This adds API documentation for `audbcards.Dataset` and `audbcards.Datacard` to the documentation.
It sounds like a good idea to me, to add this before we do our first release.

![image](https://github.com/audeering/audbcards/assets/173624/18d30531-5b03-4111-ad73-1a142a43df21)
