### PR TITLE
Add file argument to audbcards.Datacard.save()

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -39,7 +39,6 @@ class Datacard(object):
             If not ``None``
             and ``example`` is ``True``,
             a call to :meth:`audbcards.Datacard.player`
-            or :meth:`audbcards.Datacard.save`
             will store an example audio file
             under
             ``<sphinx_build_dir>/<path>/<db-name>/<media-file-in-db>``
@@ -47,7 +46,6 @@ class Datacard(object):
             If not ``None``
             and ``example`` is ``True``,
             a call to :meth:`audbcards.Datacard.player`
-            or :meth:`audbcards.Datacard.save`
             will store a wavplot of the example audio file
             under
             ``<sphinx_src_dir>/<path>/<db-name>/<db-name>.png``
@@ -239,15 +237,26 @@ class Datacard(object):
         )
         return player_str
 
-    def save(self):
-        """Save content of rendered template to rst."""
-        if self.sphinx_src_dir is not None:
-            rst_file = audeer.path(
+    def save(self, file: str = None):
+        """Save content of rendered template to rst.
+
+        Args:
+            file: name of output RST file.
+                If ``None``
+                and :attr:`audbcards.Datacard.sphinx_src_dir`
+                is not ``None``,
+                the RST file will be stored
+                as ``<sphinx_src_dir>/<path>/<dataset>.rst``
+
+        """
+        if file is None and self.sphinx_src_dir is not None:
+            file = audeer.path(
                 self.sphinx_src_dir,
                 self.path,
                 f"{self.dataset.name}.rst",
             )
-            with open(rst_file, mode="w", encoding="utf-8") as fp:
+        if file is not None:
+            with open(file, mode="w", encoding="utf-8") as fp:
                 fp.write(self.content)
 
     def _inline_image(

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -249,7 +249,6 @@ class Datacard(object):
             )
             with open(rst_file, mode="w", encoding="utf-8") as fp:
                 fp.write(self.content)
-                print(f"... wrote {rst_file}")
 
     def _inline_image(
         self,

--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -85,7 +85,12 @@ def builder_inited(app: sphinx.application.Sphinx):
             )
             datacard.save()
             datasets.append(dataset)
-            print("done")
+            output_path = os.path.join(
+                os.path.basename(app.srcdir),
+                path,
+                f"{dataset.name}.rst",
+            )
+            print(f"wrote {output_path}")
 
         # Create datasets overview page
         create_datasets_page(

--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -83,14 +83,15 @@ def builder_inited(app: sphinx.application.Sphinx):
                 sphinx_src_dir=app.srcdir,
                 example=example,
             )
-            datacard.save()
-            datasets.append(dataset)
-            output_path = os.path.join(
+            rst_file = os.path.join(
                 os.path.basename(app.srcdir),
                 path,
                 f"{dataset.name}.rst",
             )
-            print(f"wrote {output_path}")
+            datacard.save(rst_file)
+            datasets.append(dataset)
+            out_file = rst_file.replace(app.srcdir, os.path.basename(app.srcdir))
+            print(f"wrote {out_file}")
 
         # Create datasets overview page
         create_datasets_page(


### PR DESCRIPTION
This adds the `file` argument to `audbcards.Datacard.save()` to provide the user with more choice how to store a datacard.

![image](https://github.com/audeering/audbcards/assets/173624/47df064e-fa0b-4b48-b0af-0da14927c655)

It also allows us to move all the stdout print messages when running the sphinx extension to `audbcards/sphinx/__init__.py`.

It also changes the stdout from

```
Parse air-1.4.2... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/air.rst                                                                
done                                       
Parse cough-speech-sneeze-2.0.1... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/cough-speech-sneeze.rst
done                                                                                                                                                                          
Parse crema-d-1.2.0... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/crema-d.rst
done                                                                                   
Parse emodb-1.4.1... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/emodb.rst                                                            
done                                                                                                                                                                          
Parse micirp-1.0.0... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/micirp.rst                                                          
done                                                                                                                                                                          
Parse musan-1.0.0... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/musan.rst
done                                                                                   
Parse vadtoolkit-1.1.0... ... wrote /home/hwierstorf@audeering.local/git/audeering/audbcards/docs/data-public/vadtoolkit.rst                                                  
done   
```

to

```
Parse air-1.4.2... wrote docs/data-public/air.rst
Parse cough-speech-sneeze-2.0.1... wrote docs/data-public/cough-speech-sneeze.rst
Parse crema-d-1.2.0... wrote docs/data-public/crema-d.rst                         
Parse emodb-1.4.1... wrote docs/data-public/emodb.rst
Parse micirp-1.0.0... wrote docs/data-public/micirp.rst
Parse musan-1.0.0... wrote docs/data-public/musan.rst              
Parse vadtoolkit-1.1.0... wrote docs/data-public/vadtoolkit.rst
```