### PR TITLE
CI: add publish Action for PyPI and Github pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build virtualenv
+
+    # PyPI package
+    - name: Build Python package
+      run: python -m build
+
+    - name: Publish Python package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    # Documentation
+    - name: Install doc dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install -r docs/requirements.txt
+
+    - name: Build documentation
+      run: python -m sphinx docs/ build/html -b html
+
+    - name: Deploy documentation to Github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build/html
+
+    # Github release
+    - name: Read CHANGELOG
+      id: changelog
+      run: |
+        # Get bullet points from last CHANGELOG entry
+        CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+][\* ]' | sed 's/\+//')
+        echo "Got changelog: $CHANGELOG"
+        # Support for multiline, see
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        {
+          echo 'body<<EOF'
+          echo "$CHANGELOG"
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Create release on Github
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        name: Release ${{ github.ref_name }}
+        body: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
Closes #54 

This adds the `publish.yml` github Action, that will build and publish the Python package to PyPI for every tag,
and also build the documentation and publish as Github pages.

This requires that the `release` environment in this repo exists (which I created), and that the project is registered with PyPI (which I also did).