### PR TITLE
Skip duration plots for single duration

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -141,6 +141,9 @@ class Datacard(object):
         and displayed
         between the minimum and maximum values.
 
+        If all duration values are the same,
+        no distribution plot is created.
+
         """
         min_ = 0
         max_ = 0
@@ -149,6 +152,12 @@ class Datacard(object):
         if len(durations) > 0:
             min_ = np.min(durations)
             max_ = np.max(durations)
+
+        # Skip creating a distribution plot,
+        # if all durations are the same
+        if min_ == max_:
+            return f"{max_:.1f} {unit}"
+
         distribution_str = f"{min_:.1f} {unit} .. {max_:.1f} {unit}"
 
         # Save distribution plot

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -155,7 +155,7 @@ class Datacard(object):
         # Skip creating a distribution plot,
         # if all durations are the same
         if min_ == max_:
-            return f"{max_:.1f} {unit}"
+            return f"each file is {max_:.1f} {unit}"
 
         distribution_str = f"{min_:.1f} {unit} .. {max_:.1f} {unit}"
 

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -140,7 +140,6 @@ class Datacard(object):
         under ``<dataset-name>/<dataset-name>-file-durations.png``
         and displayed
         between the minimum and maximum values.
-
         If all duration values are the same,
         no distribution plot is created.
 

--- a/tests/test_data/rendered_templates/bare_db.rst
+++ b/tests/test_data/rendered_templates/bare_db.rst
@@ -14,7 +14,7 @@ channel
 sampling rate 
 bit depth     
 duration      0 days 00:00:00
-files         0, duration distribution: 0.0 s
+files         0, duration distribution: each file is 0.0 s
 repository    `data-local <.../data-local/bare_db>`__
 published     2023-04-05 by author
 ============= ======================

--- a/tests/test_data/rendered_templates/bare_db.rst
+++ b/tests/test_data/rendered_templates/bare_db.rst
@@ -14,7 +14,7 @@ channel
 sampling rate 
 bit depth     
 duration      0 days 00:00:00
-files         0, duration distribution: 0.0 s .. 0.0 s
+files         0, duration distribution: 0.0 s
 repository    `data-local <.../data-local/bare_db>`__
 published     2023-04-05 by author
 ============= ======================

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -16,7 +16,7 @@ channel       1
 sampling rate 8000
 bit depth     16
 duration      0 days 00:00:00.100000
-files         1, duration distribution: 0.1 s
+files         1, duration distribution: each file is 0.1 s
 repository    `data-local <.../data-local/minimal_db>`__
 published     2023-04-05 by author
 ============= ======================

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -16,7 +16,7 @@ channel       1
 sampling rate 8000
 bit depth     16
 duration      0 days 00:00:00.100000
-files         1, duration distribution: 0.1 s .. 0.1 s
+files         1, duration distribution: 0.1 s
 repository    `data-local <.../data-local/minimal_db>`__
 published     2023-04-05 by author
 ============= ======================

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -116,17 +116,21 @@ def test_datacard_file_duration_distribution(
         f"{db.name}-file-durations.png",
     )
     assert not os.path.exists(image_file)
-    expected_distribution_str = f"{expected_min:.1f} s .. {expected_max:.1f} s"
+    if expected_min == expected_max:
+        expected_distribution_str = f"{expected_max:.1f} s"
+    else:
+        expected_distribution_str = f"{expected_min:.1f} s .. {expected_max:.1f} s"
     assert expected_distribution_str == distribution_str
 
     # Set sphinx src and build dir and execute again
     datacard.sphinx_build_dir = build_dir
     datacard.sphinx_src_dir = src_dir
     distribution_str = datacard.file_duration_distribution
-    assert os.path.exists(image_file)
-    expected_distribution_str = (
-        f"{expected_min:.1f} s |{db.name}-file-durations| {expected_max:.1f} s"
-    )
+    if expected_min != expected_max:
+        assert os.path.exists(image_file)
+        expected_distribution_str = (
+            f"{expected_min:.1f} s |{db.name}-file-durations| {expected_max:.1f} s"
+        )
     assert expected_distribution_str == distribution_str
 
 

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -117,7 +117,7 @@ def test_datacard_file_duration_distribution(
     )
     assert not os.path.exists(image_file)
     if expected_min == expected_max:
-        expected_distribution_str = f"{expected_max:.1f} s"
+        expected_distribution_str = f"each file is {expected_max:.1f} s"
     else:
         expected_distribution_str = f"{expected_min:.1f} s .. {expected_max:.1f} s"
     assert expected_distribution_str == distribution_str


### PR DESCRIPTION
Closes #73 

This skips creating a file duration plot, if all files have the same duration and simplifies the resulting string to e.g.

```
duration distribution: each file is 0.1 s
```

![image](https://github.com/audeering/audbcards/assets/173624/c0173d2f-5b40-43bd-897f-29a25c23cf4b)