### PR TITLE
TST: ensure test datasets are loaded to tmp cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import typing
 
 import numpy as np
@@ -20,6 +21,7 @@ pytest.TEMPLATE_DIR = audeer.mkdir(
         "rendered_templates",
     )
 )
+TMP = tempfile.gettempdir()
 
 
 @pytest.fixture
@@ -55,6 +57,7 @@ def repository(tmpdir, scope="session"):
 def bare_db(
     tmpdir,
     repository,
+    audb_cache,
     scope="session",
     autouse=True,
 ):
@@ -76,13 +79,16 @@ def bare_db(
 
     # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
-    return audb.load(name, version=pytest.VERSION, verbose=False)
+    db = audb.load(name, version=pytest.VERSION, verbose=False)
+    assert db.root.startswith(TMP)
+    return db
 
 
 @pytest.fixture
 def minimal_db(
     tmpdir,
     repository,
+    audb_cache,
     scope="session",
     autouse=True,
 ):
@@ -125,13 +131,16 @@ def minimal_db(
 
     # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
-    return audb.load(name, version=pytest.VERSION, verbose=False)
+    db = audb.load(name, version=pytest.VERSION, verbose=False)
+    assert db.root.startswith(TMP)
+    return db
 
 
 @pytest.fixture
 def medium_db(
     tmpdir,
     repository,
+    audb_cache,
     scope="session",
     autouse=True,
 ):
@@ -216,7 +225,9 @@ def medium_db(
 
     # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
-    return audb.load(name, version=pytest.VERSION, verbose=False)
+    db = audb.load(name, version=pytest.VERSION, verbose=False)
+    assert db.root.startswith(TMP)
+    return db
 
 
 def create_audio_files(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 import typing
 
 import numpy as np
@@ -21,7 +20,6 @@ pytest.TEMPLATE_DIR = audeer.mkdir(
         "rendered_templates",
     )
 )
-TMP = tempfile.gettempdir()
 
 
 @pytest.fixture
@@ -80,7 +78,8 @@ def bare_db(
     # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
     db = audb.load(name, version=pytest.VERSION, verbose=False)
-    assert db.root.startswith(TMP)
+    tmp_root = str(tmpdir.parts()[1])
+    assert db.root.startswith(tmp_root)
     return db
 
 
@@ -132,7 +131,8 @@ def minimal_db(
     # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
     db = audb.load(name, version=pytest.VERSION, verbose=False)
-    assert db.root.startswith(TMP)
+    tmp_root = str(tmpdir.parts()[1])
+    assert db.root.startswith(tmp_root)
     return db
 
 
@@ -226,7 +226,8 @@ def medium_db(
     # Publish and load database
     audb.publish(db_path, pytest.VERSION, repository)
     db = audb.load(name, version=pytest.VERSION, verbose=False)
-    assert db.root.startswith(TMP)
+    tmp_root = str(tmpdir.parts()[1])
+    assert db.root.startswith(tmp_root)
     return db
 
 


### PR DESCRIPTION
This ensures that the datasets created in `test/conftest.py` are loaded to the temporary `audb` cache root set by the `audb_cache` fixture. Before, the datasets were loaded to the default `~/audb` cache root.