### PR TITLE
DOC: fix typo Datacard.file_duration_distribution

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -133,7 +133,7 @@ class Datacard(object):
         containing the mininimum and maximum values
         of files durations.
 
-        If :attr:`audbcards.Datacard.self.sphinx_src_dir` is set
+        If :attr:`audbcards.Datacard.sphinx_src_dir` is set
         (e.g. when used in the sphinx extension),
         an inline image is stored
         in the sphinx source folder


### PR DESCRIPTION
This fixes a small typo we had in `audbcards.Datacard.file_duration_distribution` when linking to `audbcards.Datacard.sphinx_src_dir` in its docstring. Before the link was towards `audbcards.Datacard.self.sphinx_src_dir`.

![image](https://github.com/audeering/audbcards/assets/173624/f0ee165f-0781-405a-a717-ce94bc2c8100)
