### PR TITLE
Store available datasets in sphinx extension

### DIFF
--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -69,6 +69,11 @@ def builder_inited(app: sphinx.application.Sphinx):
         df = df.sort_index()
         print("done")
 
+        # Store list of datasets in app
+        # to make them accessible in `docs/conf.py`
+        app.audbcards = {}
+        app.audbcards["df"] = df
+
         # Iterate datasets and create data card pages
         names = list(df.index)
         versions = list(df["version"])

--- a/docs/sphinx-extension.rst
+++ b/docs/sphinx-extension.rst
@@ -142,4 +142,14 @@ Which will render as:
     :ref:`data-public-emodb` shows the data card for emodb.
 
 
+List of available datasets
+--------------------------
+
+The sphinx extension calls at the beginning :func:`audb.available`
+to get an overview of all available datasets.
+This information can be reused inside ``docs/conf.py``
+as it is stored in the ``app.audbcards`` dictionary
+under the ``"df"`` key.
+
+
 .. _sphinx extension: https://www.sphinx-doc.org/en/master/usage/extensions/index.html

--- a/docs/sphinx-extension.rst
+++ b/docs/sphinx-extension.rst
@@ -145,11 +145,17 @@ Which will render as:
 List of available datasets
 --------------------------
 
-The sphinx extension calls at the beginning :func:`audb.available`
+The sphinx extension calls :func:`audb.available`
 to get an overview of all available datasets.
 This information can be reused inside ``docs/conf.py``
 as it is stored in the ``app.audbcards`` dictionary
-under the ``"df"`` key.
+under the ``"df"`` key, e.g.
 
+.. code-block:: python
+
+    def setup(app: sphinx.application.Sphinx):
+        df = app.audbcards["df"]
+        # ...
+        
 
 .. _sphinx extension: https://www.sphinx-doc.org/en/master/usage/extensions/index.html


### PR DESCRIPTION
This stores the result of `df = audb.available()` under `app.audbcards["df"]` in the `sphinx` extension.
This has the advantage that the data can be reused inside `docs/conf.py` by other custom code,
e.g. listing newly published datasets.

I also added a sub-section to the documentation of the sphinx extension:

![image](https://github.com/audeering/audbcards/assets/173624/a59dd9fb-34f9-45d0-9285-a51393028128)
