### PR TITLE
Add audbcards.config.CACHE_ROOT

### DIFF
--- a/audbcards/__init__.py
+++ b/audbcards/__init__.py
@@ -1,3 +1,4 @@
+from audbcards.core.config import config
 from audbcards.core.datacard import Datacard
 from audbcards.core.dataset import Dataset
 

--- a/audbcards/core/config.py
+++ b/audbcards/core/config.py
@@ -1,0 +1,19 @@
+class config:
+    r"""Get/set configuration values for the :mod:`audbcards` module.
+
+    Examples:
+        >>> config.CACHE_ROOT
+        '~/.cache/audbcards'
+        >>> config.CACHE_ROOT = "~/audbcards"
+        >>> config.CACHE_ROOT
+        '~/audbcards'
+
+    """
+
+    CACHE_ROOT = "~/.cache/audbcards"
+    r"""Default cache folder.
+
+    It can be overwritten
+    by the ``AUDBCARDS_CACHE_ROOT`` environment variable.
+
+    """

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -13,6 +13,7 @@ import audbackend
 import audeer
 import audformat
 
+from audbcards.core.config import config
 from audbcards.core.utils import format_schemes
 from audbcards.core.utils import limit_presented_samples
 
@@ -37,9 +38,11 @@ class _Dataset:
         name: str,
         version: str,
         *,
-        cache_root: str = "~/.cache/audbcards",
+        cache_root: str = None,
     ):
         r"""Instantiate Dataset Object."""
+        if cache_root is None:
+            cache_root = os.environ.get("AUDBCARDS_CACHE_ROOT") or config.CACHE_ROOT
         dataset_cache_filename = cls._dataset_cache_path(name, version, cache_root)
 
         if os.path.exists(dataset_cache_filename):
@@ -57,7 +60,7 @@ class _Dataset:
         self,
         name: str,
         version: str,
-        cache_root: str = "~./cache/audbcards",
+        cache_root: str = None,
     ):
         self.cache_root = audeer.mkdir(audeer.path(cache_root))
         self.header = audb.info.header(
@@ -499,7 +502,11 @@ class Dataset(object):
     Args:
         name: name of dataset
         version: version of dataset
-        cache_root: cache folder
+        cache_root: cache folder.
+            If ``None``,
+            the environmental variable ``AUDBCARDS_CACHE_ROOT``,
+            or :attr:`audbcards.config.CACHE_ROOT`
+            is used
 
     """
 
@@ -508,7 +515,7 @@ class Dataset(object):
         name: str,
         version: str,
         *,
-        cache_root: str = "~/.cache/audbcards",
+        cache_root: str = None,
     ):
         r"""Create Dataset Instance."""
         instance = _Dataset.create(name, version, cache_root=cache_root)

--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -39,7 +39,7 @@ def setup(app: sphinx.application.Sphinx):
 
 # ===== SPHINX EXTENSION FUNCTIONS ========================================
 #
-# All fctions defined here
+# All functions defined here
 # are added to the extension
 # via app.connect()
 # in setup()

--- a/docs/api-src/audbcards.rst
+++ b/docs/api-src/audbcards.rst
@@ -7,5 +7,6 @@ audbcards
     :toctree:
     :nosignatures:
 
+    config
     Datacard
     Dataset

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -311,6 +311,42 @@ class TestConstructor(object):
         assert list_props_uncached == list_props_cached
 
 
+@pytest.mark.parametrize(
+    "db",
+    [
+        "medium_db",
+    ],
+)
+def test_dataset_cache_root(tmpdir, request, db):
+    """Test configuration of cache root.
+
+    ``cache_root`` can be provided by different options,
+    in the following hierarchy:
+
+    * as argument to ``audbcards.Dataset()``
+    * as environment variable ``AUDBCARDS_CACHE_ROOT``
+    * as ``audbcards.config.CACHE_ROOT`` entry
+
+    """
+    db = request.getfixturevalue(db)
+    cache_root1 = audeer.mkdir(tmpdir, "cache1")
+    cache_root2 = audeer.mkdir(tmpdir, "cache2")
+    cache_root3 = audeer.mkdir(tmpdir, "cache3")
+    assert audbcards.config.CACHE_ROOT == "~/.cache/audbcards"
+    audbcards.config.CACHE_ROOT = cache_root1
+    dataset = audbcards.Dataset(db.name, pytest.VERSION)
+    assert dataset.cache_root == cache_root1
+    os.environ["AUDBCARDS_CACHE_ROOT"] = cache_root2
+    dataset = audbcards.Dataset(db.name, pytest.VERSION)
+    assert dataset.cache_root == cache_root2
+    dataset = audbcards.Dataset(
+        db.name,
+        pytest.VERSION,
+        cache_root=cache_root3,
+    )
+    assert dataset.cache_root == cache_root3
+
+
 def test_dataset_cache_path():
     """Test Value of default cache path."""
     cache_path_calculated = audbcards.core.dataset._Dataset._dataset_cache_path(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -321,7 +321,7 @@ def test_dataset_cache_root(tmpdir, request, db):
     """Test configuration of cache root.
 
     ``cache_root`` can be provided by different options,
-    in the following hierarchy:
+    in the following precedence:
 
     * as argument to ``audbcards.Dataset()``
     * as environment variable ``AUDBCARDS_CACHE_ROOT``


### PR DESCRIPTION
Closes #81 

This provides the possibility to specify the cache folder for `audbcards` by using the environment variable `AUDBCARDS_CACHE_ROOT` or the config entry `audbcards.config.CACHE_ROOT`.

![image](https://github.com/audeering/audbcards/assets/173624/6ceb3145-acfd-40a0-bac3-96af7a72aa31)
