### PR TITLE
Speedup caching of audbcards.Dataset

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -114,7 +114,8 @@ class Datacard(object):
         )
         # Download of example data might fail
         try:
-            media = self.dataset.deps.media[index]
+            files = audb.info.files(self.dataset.name, version=self.dataset.version)
+            media = files[index]
             audb.load_media(
                 self.dataset.name,
                 media,

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -395,7 +395,7 @@ class Datacard(object):
         template = environment.get_template("datacard.j2")
 
         # Convert dataset object to dictionary
-        dataset = self.dataset.cached_properties()
+        dataset = self.dataset._cached_properties()
 
         # Add additional datacard only properties
         dataset = self._expand_dataset(dataset)

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -395,7 +395,7 @@ class Datacard(object):
         template = environment.get_template("datacard.j2")
 
         # Convert dataset object to dictionary
-        dataset = self.dataset.properties()
+        dataset = self.dataset.cached_properties()
 
         # Add additional datacard only properties
         dataset = self._expand_dataset(dataset)

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -114,8 +114,7 @@ class Datacard(object):
         )
         # Download of example data might fail
         try:
-            files = audb.info.files(self.dataset.name, version=self.dataset.version)
-            media = files[index]
+            media = self.dataset.deps.media[index]
             audb.load_media(
                 self.dataset.name,
                 media,

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -109,7 +109,7 @@ class _Dataset:
 
     @property
     def backend(self) -> audbackend.Backend:
-        r"""Dataset dependency table."""
+        r"""Dataset backend object."""
         if not hasattr(self, "_backend"):  # when loaded from cache
             self._backend = self._load_backend()
         return self._backend

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -121,7 +121,7 @@ class _Dataset:
     @property
     def deps(self) -> audb.Dependencies:
         r"""Dataset dependency table."""
-        if self._deps is None:  # when loaded from cache
+        if not hasattr(self, "_deps"):  # when loaded from cache
             self._deps = audb.dependencies(
                 self.name,
                 version=self.version,
@@ -132,7 +132,7 @@ class _Dataset:
     @property
     def header(self) -> audformat.Database:
         r"""Dataset header."""
-        if self._header is None:  # when loaded from cache
+        if not hasattr(self, "_header"):  # when loaded from cache
             self._header = audb.info.header(
                 self.name,
                 version=self.version,
@@ -143,12 +143,12 @@ class _Dataset:
     @functools.cached_property
     def archives(self) -> int:
         r"""Number of archives of media files in dataset."""
-        return len(set([self._deps.archive(file) for file in self._deps.media]))
+        return len(set([self.deps.archive(file) for file in self.deps.media]))
 
     @functools.cached_property
     def author(self) -> typing.List[str]:
         r"""Authors of the database."""
-        return self._header.author
+        return self.header.author
 
     @functools.cached_property
     def bit_depths(self) -> typing.List[int]:
@@ -157,9 +157,9 @@ class _Dataset:
             list(
                 set(
                     [
-                        self._deps.bit_depth(file)
-                        for file in self._deps.media
-                        if self._deps.bit_depth(file)
+                        self.deps.bit_depth(file)
+                        for file in self.deps.media
+                        if self.deps.bit_depth(file)
                     ]
                 )
             )
@@ -172,9 +172,9 @@ class _Dataset:
             list(
                 set(
                     [
-                        self._deps.channels(file)
-                        for file in self._deps.media
-                        if self._deps.channels(file)
+                        self.deps.channels(file)
+                        for file in self.deps.media
+                        if self.deps.channels(file)
                     ]
                 )
             )
@@ -183,12 +183,12 @@ class _Dataset:
     @functools.cached_property
     def description(self) -> str:
         r"""Source of the database."""
-        return self._header.description
+        return self.header.description
 
     @functools.cached_property
     def duration(self) -> pd.Timedelta:
         r"""Total duration of media files in dataset."""
-        durations = [self._deps.duration(file) for file in self._deps.media]
+        durations = [self.deps.duration(file) for file in self.deps.media]
         return pd.to_timedelta(
             sum([d for d in durations if d is not None]),
             unit="s",
@@ -197,22 +197,22 @@ class _Dataset:
     @functools.cached_property
     def files(self) -> int:
         r"""Number of media files in dataset."""
-        return len(self._deps.media)
+        return len(self.deps.media)
 
     @functools.cached_property
     def file_durations(self) -> typing.List:
         r"""File durations in dataset in seconds."""
-        return [self._deps.duration(file) for file in self._deps.media]
+        return [self.deps.duration(file) for file in self.deps.media]
 
     @functools.cached_property
     def formats(self) -> typing.List[str]:
         r"""File formats of media files in dataset."""
-        return sorted(list(set([self._deps.format(file) for file in self._deps.media])))
+        return sorted(list(set([self.deps.format(file) for file in self.deps.media])))
 
     @functools.cached_property
     def languages(self) -> typing.List[str]:
         r"""Languages of the database."""
-        return self._header.languages
+        return self.header.languages
 
     @functools.cached_property
     def iso_languages(self) -> typing.List[str]:
@@ -227,7 +227,7 @@ class _Dataset:
         ``'Unknown'`` is returned.
 
         """
-        return self._header.license or "Unknown"
+        return self.header.license or "Unknown"
 
     @functools.cached_property
     def license_link(self) -> typing.Optional[str]:
@@ -237,10 +237,10 @@ class _Dataset:
         ``None`` is returned.
 
         """
-        if self._header.license_url is None or len(self._header.license_url) == 0:
+        if self.header.license_url is None or len(self.header.license_url) == 0:
             return None
         else:
-            return self._header.license_url
+            return self.header.license_url
 
     @functools.cached_property
     def name(self) -> str:
@@ -293,9 +293,9 @@ class _Dataset:
             list(
                 set(
                     [
-                        self._deps.sampling_rate(file)
-                        for file in self._deps.media
-                        if self._deps.sampling_rate(file)
+                        self.deps.sampling_rate(file)
+                        for file in self.deps.media
+                        if self.deps.sampling_rate(file)
                     ]
                 )
             )
@@ -304,7 +304,7 @@ class _Dataset:
     @functools.cached_property
     def schemes(self) -> typing.List[str]:
         r"""Schemes of dataset."""
-        return list(self._header.schemes)
+        return list(self.header.schemes)
 
     @functools.cached_property
     def schemes_summary(self) -> str:
@@ -316,7 +316,7 @@ class _Dataset:
         e.g. ``'speaker: [age, gender, language]'``.
 
         """
-        return format_schemes(self._header.schemes)
+        return format_schemes(self.header.schemes)
 
     @functools.cached_property
     def schemes_table(self) -> typing.List[typing.List[str]]:
@@ -326,7 +326,7 @@ class _Dataset:
         with column names as keys.
 
         """
-        db = self._header
+        db = self.header
         dataset_schemes = []
         for scheme_id in db.schemes:
             dataset_scheme = self._scheme_to_list(scheme_id)
@@ -345,7 +345,7 @@ class _Dataset:
     def short_description(self) -> str:
         r"""Description of dataset shortened to 150 chars."""
         length = 150
-        description = self._header.description or ""
+        description = self.header.description or ""
         # Fix RST used signs
         description = description.replace("`", "'")
         if len(description) > length:
@@ -355,12 +355,12 @@ class _Dataset:
     @functools.cached_property
     def source(self) -> str:
         r"""Source of the database."""
-        return self._header.source
+        return self.header.source
 
     @functools.cached_property
     def tables(self) -> typing.List[str]:
         """Tables of the dataset."""
-        db = self._header
+        db = self.header
         tables = list(db)
         return tables
 
@@ -368,7 +368,7 @@ class _Dataset:
     def tables_table(self) -> typing.List[str]:
         """Tables of the dataset."""
         table_list = [["ID", "Type", "Columns"]]
-        db = self._header
+        db = self.header
         for table_id in self.tables:
             table = db[table_id]
             if isinstance(table, audformat.MiscTable):
@@ -383,7 +383,7 @@ class _Dataset:
     @functools.cached_property
     def usage(self) -> str:
         r"""Usage of the database."""
-        return self._header.usage
+        return self.header.usage
 
     @functools.cached_property
     def version(self) -> str:
@@ -402,7 +402,7 @@ class _Dataset:
         ``'Mappings'``.
 
         """
-        schemes = self._header.schemes
+        schemes = self.header.schemes
 
         if len(schemes) == 0:
             return []
@@ -422,7 +422,7 @@ class _Dataset:
         return columns
 
     def _scheme_to_list(self, scheme_id):
-        db = self._header
+        db = self.header
         scheme_info = self._scheme_table_columns
 
         scheme = db.schemes[scheme_id]

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -4,7 +4,6 @@ import os
 import pickle
 import typing
 
-import dohq_artifactory
 import jinja2
 import pandas as pd
 
@@ -16,19 +15,6 @@ import audformat
 from audbcards.core.config import config
 from audbcards.core.utils import format_schemes
 from audbcards.core.utils import limit_presented_samples
-
-
-def _getstate(self):
-    return self.name
-
-
-def _setstate(self, state):
-    self.name = state
-
-
-# Ensure we can pickle the repository
-dohq_artifactory.GenericRepository.__getstate__ = _getstate
-dohq_artifactory.GenericRepository.__setstate__ = _setstate
 
 
 class _Dataset:
@@ -94,6 +80,10 @@ class _Dataset:
         other_versions = [v for v in versions if v != version]
         for other_version in other_versions:
             audeer.rmdir(audeer.path(self.cache_root, name, other_version))
+
+    def __get_state__(self):
+        r"""Returns attributes to be pickled."""
+        return self.properties
 
     @staticmethod
     def _dataset_cache_path(name: str, version: str, cache_root: str) -> str:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -48,7 +48,8 @@ class _Dataset:
         version: str,
         cache_root: str = None,
     ):
-        audeer.mkdir(cache_root)
+        self.cache_root = audeer.mkdir(cache_root)
+        r"""Cache root folder."""
 
         # Store name and version in private attributes here,
         # ``self.name`` and ``self.version``

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -315,6 +315,11 @@ class _Dataset:
         on schemes named ``'emotion'`` and ``'speaker'``,
         e.g. ``'speaker: [age, gender, language]'``.
 
+        Example:
+            >>> ds = Dataset("emodb", "1.4.1")
+            >>> ds.schemes_summary
+            'emotion: [anger, ..., neutral], speaker: [age, ..., language], ...'
+
         """
         return format_schemes(self.header.schemes)
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -37,7 +37,7 @@ class _Dataset:
             return obj
 
         obj = cls(name, version, cache_root)
-        _ = obj.cached_properties()
+        _ = obj._cached_properties()
 
         cls._save_pickled(obj, dataset_cache_filename)
         return obj
@@ -77,7 +77,7 @@ class _Dataset:
 
     def __getstate__(self):
         r"""Returns attributes to be pickled."""
-        return self.cached_properties()
+        return self._cached_properties()
 
     @staticmethod
     def _dataset_cache_path(name: str, version: str, cache_root: str) -> str:
@@ -375,7 +375,7 @@ class _Dataset:
         r"""Version of dataset."""
         return self._version
 
-    def cached_properties(self):
+    def _cached_properties(self):
         """Get list of cached properties of the object."""
         class_items = self.__class__.__dict__.items()
         props = dict(

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -571,12 +571,12 @@ class Dataset(object):
 
     # Copy attributes and methods
     # to include in documentation
-    for prop in [
+    for _prop in [  # use private variable `_prop` to avoid inclusion in API doc
         name
         for name, value in inspect.getmembers(_Dataset)
-        if isinstance(value, functools.cached_property) and not name.startswith("_")
+        if not name.startswith("_") and name not in ["create"]
     ]:
-        vars()[prop] = getattr(_Dataset, prop)
+        vars()[_prop] = getattr(_Dataset, _prop)
 
     @staticmethod
     def _map_iso_languages(*args):

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -569,6 +569,18 @@ class Dataset(object):
         instance = _Dataset.create(name, version, cache_root=cache_root)
         return instance
 
+    # Add an __init__() function,
+    # to allow documenting instance variables
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        *,
+        cache_root: str = None,
+    ):
+        self.cache_root = audeer.mkdir(cache_root)
+        r"""Cache root folder."""
+
     # Copy attributes and methods
     # to include in documentation
     for prop in [

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -571,12 +571,12 @@ class Dataset(object):
 
     # Copy attributes and methods
     # to include in documentation
-    for _prop in [  # use private variable `_prop` to avoid inclusion in API doc
+    for prop in [
         name
         for name, value in inspect.getmembers(_Dataset)
         if not name.startswith("_") and name not in ["create"]
     ]:
-        vars()[_prop] = getattr(_Dataset, _prop)
+        vars()[prop] = getattr(_Dataset, prop)
 
     @staticmethod
     def _map_iso_languages(*args):

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -310,11 +310,6 @@ class _Dataset:
         on schemes named ``'emotion'`` and ``'speaker'``,
         e.g. ``'speaker: [age, gender, language]'``.
 
-        Example:
-            >>> ds = Dataset("emodb", "1.4.1")
-            >>> ds.schemes_summary
-            'emotion: [anger, ..., neutral], speaker: [age, ..., language], ...'
-
         """
         return format_schemes(self.header.schemes)
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -130,7 +130,7 @@ class _Dataset:
 
     @property
     def repository_object(self) -> audb.Repository:
-        r"""Repository containing dataset."""
+        r"""Repository object containing dataset."""
         if not hasattr(self, "_repository_object"):  # when loaded from cache
             self._repository_object = self._load_repository_object()
         return self._repository_object

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -48,7 +48,7 @@ class _Dataset:
         version: str,
         cache_root: str = None,
     ):
-        self.cache_root = audeer.mkdir(cache_root)
+        audeer.mkdir(cache_root)
 
         # Store name and version in private attributes here,
         # ``self.name`` and ``self.version``
@@ -79,12 +79,12 @@ class _Dataset:
         # by removing all other versions of the same dataset
         # to reduce its storage size in CI runners
         versions = audeer.list_dir_names(
-            audeer.path(self.cache_root, name),
+            audeer.path(cache_root, name),
             basenames=True,
         )
         other_versions = [v for v in versions if v != version]
         for other_version in other_versions:
-            audeer.rmdir(audeer.path(self.cache_root, name, other_version))
+            audeer.rmdir(cache_root, name, other_version)
 
     def __getstate__(self):
         r"""Returns attributes to be pickled."""
@@ -93,7 +93,7 @@ class _Dataset:
     @staticmethod
     def _dataset_cache_path(name: str, version: str, cache_root: str) -> str:
         r"""Generate the name of the cache file."""
-        cache_dir = audeer.mkdir(audeer.path(cache_root, name, version))
+        cache_dir = audeer.mkdir(cache_root, name, version)
 
         cache_filename = audeer.path(
             cache_dir,
@@ -143,12 +143,12 @@ class _Dataset:
     @functools.cached_property
     def archives(self) -> int:
         r"""Number of archives of media files in dataset."""
-        return len(set([self.deps.archive(file) for file in self.deps.media]))
+        return len(set([self._deps.archive(file) for file in self._deps.media]))
 
     @functools.cached_property
     def author(self) -> typing.List[str]:
         r"""Authors of the database."""
-        return self.header.author
+        return self._header.author
 
     @functools.cached_property
     def bit_depths(self) -> typing.List[int]:
@@ -157,9 +157,9 @@ class _Dataset:
             list(
                 set(
                     [
-                        self.deps.bit_depth(file)
-                        for file in self.deps.media
-                        if self.deps.bit_depth(file)
+                        self._deps.bit_depth(file)
+                        for file in self._deps.media
+                        if self._deps.bit_depth(file)
                     ]
                 )
             )
@@ -172,9 +172,9 @@ class _Dataset:
             list(
                 set(
                     [
-                        self.deps.channels(file)
-                        for file in self.deps.media
-                        if self.deps.channels(file)
+                        self._deps.channels(file)
+                        for file in self._deps.media
+                        if self._deps.channels(file)
                     ]
                 )
             )
@@ -183,12 +183,12 @@ class _Dataset:
     @functools.cached_property
     def description(self) -> str:
         r"""Source of the database."""
-        return self.header.description
+        return self._header.description
 
     @functools.cached_property
     def duration(self) -> pd.Timedelta:
         r"""Total duration of media files in dataset."""
-        durations = [self.deps.duration(file) for file in self.deps.media]
+        durations = [self._deps.duration(file) for file in self._deps.media]
         return pd.to_timedelta(
             sum([d for d in durations if d is not None]),
             unit="s",
@@ -197,22 +197,22 @@ class _Dataset:
     @functools.cached_property
     def files(self) -> int:
         r"""Number of media files in dataset."""
-        return len(self.deps.media)
+        return len(self._deps.media)
 
     @functools.cached_property
     def file_durations(self) -> typing.List:
         r"""File durations in dataset in seconds."""
-        return [self.deps.duration(file) for file in self.deps.media]
+        return [self._deps.duration(file) for file in self._deps.media]
 
     @functools.cached_property
     def formats(self) -> typing.List[str]:
         r"""File formats of media files in dataset."""
-        return sorted(list(set([self.deps.format(file) for file in self.deps.media])))
+        return sorted(list(set([self._deps.format(file) for file in self._deps.media])))
 
     @functools.cached_property
     def languages(self) -> typing.List[str]:
         r"""Languages of the database."""
-        return self.header.languages
+        return self._header.languages
 
     @functools.cached_property
     def iso_languages(self) -> typing.List[str]:
@@ -227,7 +227,7 @@ class _Dataset:
         ``'Unknown'`` is returned.
 
         """
-        return self.header.license or "Unknown"
+        return self._header.license or "Unknown"
 
     @functools.cached_property
     def license_link(self) -> typing.Optional[str]:
@@ -237,10 +237,10 @@ class _Dataset:
         ``None`` is returned.
 
         """
-        if self.header.license_url is None or len(self.header.license_url) == 0:
+        if self._header.license_url is None or len(self._header.license_url) == 0:
             return None
         else:
-            return self.header.license_url
+            return self._header.license_url
 
     @functools.cached_property
     def name(self) -> str:
@@ -293,9 +293,9 @@ class _Dataset:
             list(
                 set(
                     [
-                        self.deps.sampling_rate(file)
-                        for file in self.deps.media
-                        if self.deps.sampling_rate(file)
+                        self._deps.sampling_rate(file)
+                        for file in self._deps.media
+                        if self._deps.sampling_rate(file)
                     ]
                 )
             )
@@ -304,7 +304,7 @@ class _Dataset:
     @functools.cached_property
     def schemes(self) -> typing.List[str]:
         r"""Schemes of dataset."""
-        return list(self.header.schemes)
+        return list(self._header.schemes)
 
     @functools.cached_property
     def schemes_table(self) -> typing.List[typing.List[str]]:
@@ -314,7 +314,7 @@ class _Dataset:
         with column names as keys.
 
         """
-        db = self.header
+        db = self._header
         dataset_schemes = []
         for scheme_id in db.schemes:
             dataset_scheme = self._scheme_to_list(scheme_id)
@@ -333,7 +333,7 @@ class _Dataset:
     def short_description(self) -> str:
         r"""Description of dataset shortened to 150 chars."""
         length = 150
-        description = self.header.description or ""
+        description = self._header.description or ""
         # Fix RST used signs
         description = description.replace("`", "'")
         if len(description) > length:
@@ -343,12 +343,12 @@ class _Dataset:
     @functools.cached_property
     def source(self) -> str:
         r"""Source of the database."""
-        return self.header.source
+        return self._header.source
 
     @functools.cached_property
     def tables(self) -> typing.List[str]:
         """Tables of the dataset."""
-        db = self.header
+        db = self._header
         tables = list(db)
         return tables
 
@@ -356,7 +356,7 @@ class _Dataset:
     def tables_table(self) -> typing.List[str]:
         """Tables of the dataset."""
         table_list = [["ID", "Type", "Columns"]]
-        db = self.header
+        db = self._header
         for table_id in self.tables:
             table = db[table_id]
             if isinstance(table, audformat.MiscTable):
@@ -371,7 +371,7 @@ class _Dataset:
     @functools.cached_property
     def usage(self) -> str:
         r"""Usage of the database."""
-        return self.header.usage
+        return self._header.usage
 
     @functools.cached_property
     def version(self) -> str:
@@ -390,7 +390,7 @@ class _Dataset:
         ``'Mappings'``.
 
         """
-        schemes = self.header.schemes
+        schemes = self._header.schemes
 
         if len(schemes) == 0:
             return []
@@ -410,7 +410,7 @@ class _Dataset:
         return columns
 
     def _scheme_to_list(self, scheme_id):
-        db = self.header
+        db = self._header
         scheme_info = self._scheme_table_columns
 
         scheme = db.schemes[scheme_id]

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -37,7 +37,7 @@ class _Dataset:
             return obj
 
         obj = cls(name, version, cache_root)
-        _ = obj.properties()
+        _ = obj.cached_properties()
 
         cls._save_pickled(obj, dataset_cache_filename)
         return obj
@@ -77,7 +77,7 @@ class _Dataset:
 
     def __getstate__(self):
         r"""Returns attributes to be pickled."""
-        return self.properties()
+        return self.cached_properties()
 
     @staticmethod
     def _dataset_cache_path(name: str, version: str, cache_root: str) -> str:
@@ -254,16 +254,6 @@ class _Dataset:
         path = self.backend.join("/", self.name, "db.yaml")
         return self.backend.owner(path, self.version)
 
-    def properties(self):
-        """Get list of properties of the object."""
-        class_items = self.__class__.__dict__.items()
-        props = dict(
-            (k, getattr(self, k))
-            for k, v in class_items
-            if isinstance(v, functools.cached_property)
-        )
-        return props
-
     @functools.cached_property
     def repository(self) -> str:
         r"""Repository containing the dataset."""
@@ -384,6 +374,16 @@ class _Dataset:
     def version(self) -> str:
         r"""Version of dataset."""
         return self._version
+
+    def cached_properties(self):
+        """Get list of cached properties of the object."""
+        class_items = self.__class__.__dict__.items()
+        props = dict(
+            (k, getattr(self, k))
+            for k, v in class_items
+            if isinstance(v, functools.cached_property)
+        )
+        return props
 
     def _load_backend(self) -> audbackend.Backend:
         r"""Load backend containing dataset."""

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import typing
 
+# import dohq_artifactory
 import jinja2
 import pandas as pd
 
@@ -15,6 +16,19 @@ import audformat
 from audbcards.core.config import config
 from audbcards.core.utils import format_schemes
 from audbcards.core.utils import limit_presented_samples
+
+
+# def _getstate(self):
+#     return self.name
+#
+#
+# def _setstate(self, state):
+#     self.name = state
+#
+#
+# # Ensure we can pickle the repository
+# dohq_artifactory.GenericRepository.__getstate__ = _getstate
+# dohq_artifactory.GenericRepository.__setstate__ = _setstate
 
 
 class _Dataset:
@@ -81,7 +95,7 @@ class _Dataset:
         for other_version in other_versions:
             audeer.rmdir(audeer.path(self.cache_root, name, other_version))
 
-    def __get_state__(self):
+    def __getstate__(self):
         r"""Returns attributes to be pickled."""
         return self.properties
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -393,7 +393,7 @@ class _Dataset:
             repository=self.repository,
         )
         if isinstance(backend, audbackend.Artifactory):
-            backend._use_legacy_file_structure()  # pragma: nocover
+            backend._use_legacy_file_structure()
         return backend
 
     def _load_dependencies(self) -> audb.Dependencies:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -307,6 +307,18 @@ class _Dataset:
         return list(self._header.schemes)
 
     @functools.cached_property
+    def schemes_summary(self) -> str:
+        r"""Summary of dataset schemes.
+
+        It lists all schemes in a string,
+        showing additional information
+        on schemes named ``'emotion'`` and ``'speaker'``,
+        e.g. ``'speaker: [age, gender, language]'``.
+
+        """
+        return format_schemes(self._header.schemes)
+
+    @functools.cached_property
     def schemes_table(self) -> typing.List[typing.List[str]]:
         """Schemes table with name, type, min, max, labels, mappings.
 
@@ -606,7 +618,7 @@ def create_datasets_page(
             dataset.short_description,
             f"`{dataset.license} <{dataset.license_link}>`__",
             dataset.version,
-            format_schemes(dataset.header.schemes),
+            dataset.schemes_summary,
         )
         for dataset in datasets
     ]

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -97,7 +97,7 @@ class _Dataset:
 
     def __getstate__(self):
         r"""Returns attributes to be pickled."""
-        return self.properties
+        return self.properties()
 
     @staticmethod
     def _dataset_cache_path(name: str, version: str, cache_root: str) -> str:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -245,14 +245,14 @@ class _Dataset:
     @functools.cached_property
     def publication_date(self) -> str:
         r"""Date dataset was uploaded to repository."""
-        path = self._backend.join("/", self.name, "db.yaml")
-        return self._backend.date(path, self._version)
+        path = self.backend.join("/", self.name, "db.yaml")
+        return self.backend.date(path, self.version)
 
     @functools.cached_property
     def publication_owner(self) -> str:
         r"""User who uploaded dataset to repository."""
-        path = self._backend.join("/", self.name, "db.yaml")
-        return self._backend.owner(path, self._version)
+        path = self.backend.join("/", self.name, "db.yaml")
+        return self.backend.owner(path, self.version)
 
     def properties(self):
         """Get list of properties of the object."""
@@ -393,8 +393,8 @@ class _Dataset:
     def _load_backend(self) -> audbackend.Backend:
         r"""Load backend containing dataset."""
         backend = audbackend.access(
-            name=self._repository_object.backend,
-            host=self._repository_object.host,
+            name=self.repository_object.backend,
+            host=self.repository_object.host,
             repository=self.repository,
         )
         if isinstance(backend, audbackend.Artifactory):

--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 import sphinx
+import sphinx.application
 
 import audb
 import audeer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ xfail_strict = true
 addopts = '''
     --doctest-modules
     --ignore=docs/
+    --ignore=audbcards/sphinx/
 '''
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,6 @@ skip = './audbcards.egg-info,./build'
 [tool.pytest.ini_options]
 cache_dir = '.cache/pytest'
 xfail_strict = true
-addopts = '''
-    --doctest-modules
-    --ignore=docs/
-    --ignore=audbcards/sphinx/
-'''
 
 
 # ----- ruff --------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ skip = './audbcards.egg-info,./build'
 [tool.pytest.ini_options]
 cache_dir = '.cache/pytest'
 xfail_strict = true
+addopts = '''
+    --doctest-modules
+    --ignore=docs/
+'''
 
 
 # ----- ruff --------------------------------------------------------------

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
+audb >=1.6.5  # for audb.Dependencies.__eq__()
 audeer >=1.21.0
 pytest

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -73,7 +73,8 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     # __init__
     assert dataset.name == db.name
     assert dataset.version == pytest.VERSION
-    assert dataset._repository == repository
+    assert dataset.repository_object == repository
+    assert dataset.backend == backend
     expected_header = audb.info.header(
         db.name,
         version=pytest.VERSION,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -398,16 +398,16 @@ def test_dataset_cache_loading(audb_cache, tmpdir, repository, db, request):
         host=repository.host,
         repository=repository.name,
     )
-    # header = audb.info.header(
-    #     db.name,
-    #     version=pytest.VERSION,
-    #     cache_root=audb_cache,
-    # )
+    header = audb.info.header(
+        db.name,
+        version=pytest.VERSION,
+        load_tables=True,
+        cache_root=audb_cache,
+    )
     assert dataset.backend == backend
     assert dataset.deps == deps
-    # Disabled due to potential audformat issue:
-    # the `files` table cannot be found in cache,
-    # which is requested when using `load_tables=True`
-    # in `audb.info.header`.
-    # assert dataset.header == header
+    # The dataset header is a not fully loaded `audformat.Database` object,
+    # so we cannot directly use `audformat.Database.__eq__()`
+    # to compare it.
+    assert str(dataset.header) == str(header)
     assert dataset.repository_object == repository

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -29,7 +29,7 @@ def test_dataset_property_scope(tmpdir, db, request):
         cache_root=dataset_cache,
     )
 
-    props = [x for x in dataset.properties().keys()]
+    props = [x for x in dataset.cached_properties().keys()]
 
     # should not exist in local scope
     for prop in props:
@@ -305,8 +305,8 @@ class TestConstructor(object):
     def test_props_equal(self, constructor):
         """Cached and uncached datasets have equal props."""
         ds_uncached, ds_cached, _ = constructor
-        props_uncached = ds_uncached.properties()
-        props_cached = ds_cached.properties()
+        props_uncached = ds_uncached.cached_properties()
+        props_cached = ds_cached.cached_properties()
         list_props_uncached = list(props_uncached.keys())
         list_props_cached = list(props_cached.keys())
         assert list_props_uncached == list_props_cached

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -29,7 +29,7 @@ def test_dataset_property_scope(tmpdir, db, request):
         cache_root=dataset_cache,
     )
 
-    props = [x for x in dataset.cached_properties().keys()]
+    props = [x for x in dataset._cached_properties().keys()]
 
     # should not exist in local scope
     for prop in props:
@@ -305,8 +305,8 @@ class TestConstructor(object):
     def test_props_equal(self, constructor):
         """Cached and uncached datasets have equal props."""
         ds_uncached, ds_cached, _ = constructor
-        props_uncached = ds_uncached.cached_properties()
-        props_cached = ds_cached.cached_properties()
+        props_uncached = ds_uncached._cached_properties()
+        props_cached = ds_cached._cached_properties()
         list_props_uncached = list(props_uncached.keys())
         list_props_cached = list(props_cached.keys())
         assert list_props_uncached == list_props_cached


### PR DESCRIPTION
When caching `audbcards.Dataset` we store objects that are not needed to create a datacard,
e.g. the dependency table and header of a dataset. This increases the size of the cache and makes loading slower than it is needed.
This pull request speeds up caching of `audbcards.Dataset` by pickling only cached properties, as listed by `audbcards.Dataset._cached_properties()` (formerly `audbcards.Dataset.properties()`).

The execution time for building our database overview page is as follows on compute5:

| branch | fresh build | build from cache |
| --- | --- | --- |
| main | 15 minutes | 3 minutes |
| this branch | 15 minutes | 2 minutes |

The size of the cache is reduced from 2.6G to 133M.

We can further improve execution time by also caching the images / audio examples from `audbcards.Datacard`, but I will handle this in a follow up pull request.

---

Further changes:

* Renamed `audbcards.Dataset.properties()` to `audbcards.Dataset._cached_properties()`
* Added cached property `audbcards.Dataset.schemes_summary`, that holds entries needed for the dataset overview page
* Added docstring for `audbcards.Dataset.cache_root` attribute
* Converted `audbcards.Dataset.deps` and `audbcards.Dataset.header` to properties, and added them to the documentation
* Added `audbcards.Dataset.backend` and `audbcards.Dataset.repository_object` properties
* Removed adding `__getstate__` and `__setstate__` methods to the `dohq_artifactory.GenericRepository` object, as the repository is no longer pickled

---

Newly added API entries:

![image](https://github.com/audeering/audbcards/assets/173624/e9b13381-89a5-4bc3-a347-14760e45fb06)

![image](https://github.com/audeering/audbcards/assets/173624/534160fe-1583-426e-87f5-30f69eff474c)

![image](https://github.com/audeering/audbcards/assets/173624/eaf50e59-19e0-4b7f-aef9-f0db4469d5dd)

![image](https://github.com/audeering/audbcards/assets/173624/045a2268-3f8d-4494-af7e-75d75a13553a)

![image](https://github.com/audeering/audbcards/assets/173624/1534593f-409b-423a-b8b4-811b8aa3f97a)

![image](https://github.com/audeering/audbcards/assets/173624/519eaf9e-7bf6-4e34-83cb-4394672ba6c0)