### PR TITLE
Add Dataset.example_media and cache Datacards

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -112,7 +112,7 @@ class Datacard(object):
         ``<cache-root>/<dataset-name>/<dataset-version>/``
         and copied to the sphinx source folder
         under
-        ``<dataset-name>/``.
+        ``<sphinx-src-dir>/<dataset-name>/``.
         The image is displayed inline
         between the minimum and maximum values.
         If all duration values are the same,
@@ -178,14 +178,26 @@ class Datacard(object):
         or :attr:`audbcards.Datacard.sphinx_src_dir`
         are not ``None``,
         an example media file is cached in the folder
-        ``${cache_root}/{name}-{version}-player-media/``,
+        ``<dataset-name>-<dataset-version>-player-media/``
+        inside
+        ``<cache-root>/<dataset-name>/<dataset-version>/``,
         using the same sub-folder structure
         as the media file has inside its dataset.
+        If :attr:`audbcards.Datacard.sphinx_build_dir`
+        is not ``None``,
+        the media sub-folder structure
+        is also copied
+        to the sphinx build dir under
+        ``<sphinx-build-dir>/<repository-name>/<dataset-name>/``.
 
         If :attr:`audbcards.Datacard.sphinx_src_dir` is not ``None``,
         an plot of the waveform of the media file
-        is cached at
-        ``${cache_root}/{name}-{version}-player-waveform.png``.
+        is cached under
+        ``<dataset-name>-<dataset-version>-player-waveform.png``
+        inside
+        ``<cache-root>/<dataset-name>/<dataset-version>/``.
+        It is also copied to the sphinx source folder into
+        ``<sphinx-src-dir>/<repository-name>/<dataset-name>/``.
 
         Returns:
             String containing RST code to include the player

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -203,21 +203,6 @@ class Datacard(object):
             String containing RST code to include the player
 
         """
-        # Cache is organized as `<cache_root>/<name>/<version>/`
-        cache_folder = audeer.path(
-            self.cache_root,
-            self.dataset.name,
-            self.dataset.version,
-        )
-        cache_example_media = audeer.path(
-            cache_folder,
-            f"{self.dataset.name}-{self.dataset.version}-player-media",
-            self.dataset.example_media,
-        )
-        cache_waveform_file = audeer.path(
-            cache_folder,
-            f"{self.dataset.name}-{self.dataset.version}-player-waveform.png",
-        )
 
         def load_media_to_cache(cache_example_media: str):
             r"""Load media file with audb and copy to audbcards cache.
@@ -234,6 +219,22 @@ class Datacard(object):
             )[0]
             audeer.mkdir(os.path.dirname(cache_example_media))
             shutil.copy(media, cache_example_media)
+
+        # Cache is organized as `<cache_root>/<name>/<version>/`
+        cache_folder = audeer.path(
+            self.cache_root,
+            self.dataset.name,
+            self.dataset.version,
+        )
+        cache_example_media = audeer.path(
+            cache_folder,
+            f"{self.dataset.name}-{self.dataset.version}-player-media",
+            self.dataset.example_media,
+        )
+        cache_waveform_file = audeer.path(
+            cache_folder,
+            f"{self.dataset.name}-{self.dataset.version}-player-waveform.png",
+        )
 
         # Add plot of waveform
         if self.sphinx_src_dir is not None:

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -111,7 +111,7 @@ class Datacard(object):
         which is cached in
         ``<cache-root>/<dataset-name>/<dataset-version>/``
         and copied to the sphinx source folder
-        under
+        into
         ``<sphinx-src-dir>/<dataset-name>/``.
         The image is displayed inline
         between the minimum and maximum values.
@@ -187,11 +187,11 @@ class Datacard(object):
         is not ``None``,
         the media sub-folder structure
         is also copied
-        to the sphinx build dir under
+        to the sphinx build dir into
         ``<sphinx-build-dir>/<repository-name>/<dataset-name>/``.
 
         If :attr:`audbcards.Datacard.sphinx_src_dir` is not ``None``,
-        an plot of the waveform of the media file
+        a plot of the waveform of the media file
         is cached under
         ``<dataset-name>-<dataset-version>-player-waveform.png``
         inside

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -42,14 +42,14 @@ class Datacard(object):
             a call to :meth:`audbcards.Datacard.player`
             will store an example audio file
             under
-            ``<sphinx_build_dir>/<path>/<db-name>/<media-file-in-db>``
+            ``<sphinx_build_dir>/<path>/<dataset-name>/``
         sphinx_src_dir: source dir of sphinx.
             If not ``None``
             and ``example`` is ``True``,
             a call to :meth:`audbcards.Datacard.player`
-            will store a wavplot of the example audio file
+            will store a wavform plot of the example audio file
             under
-            ``<sphinx_src_dir>/<path>/<db-name>/<db-name>.png``
+            ``<sphinx_src_dir>/<path>/<dataset-name>/``
         cache_root: cache folder.
             If ``None``,
             the environmental variable ``AUDBCARDS_CACHE_ROOT``,
@@ -112,7 +112,7 @@ class Datacard(object):
         ``<cache-root>/<dataset-name>/<dataset-version>/``
         and copied to the sphinx source folder
         into
-        ``<sphinx-src-dir>/<dataset-name>/``.
+        ``<sphinx-src-dir>/<path><dataset-name>/``.
         The image is displayed inline
         between the minimum and maximum values.
         If all duration values are the same,
@@ -188,7 +188,7 @@ class Datacard(object):
         the media sub-folder structure
         is also copied
         to the sphinx build dir into
-        ``<sphinx-build-dir>/<repository-name>/<dataset-name>/``.
+        ``<sphinx-build-dir>/<path>/<dataset-name>/``.
 
         If :attr:`audbcards.Datacard.sphinx_src_dir` is not ``None``,
         a plot of the waveform of the media file
@@ -197,7 +197,7 @@ class Datacard(object):
         inside
         ``<cache-root>/<dataset-name>/<dataset-version>/``.
         It is also copied to the sphinx source folder into
-        ``<sphinx-src-dir>/<repository-name>/<dataset-name>/``.
+        ``<sphinx-src-dir>/<path>/<dataset-name>/``.
 
         Returns:
             String containing RST code to include the player

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -47,7 +47,7 @@ class Datacard(object):
             If not ``None``
             and ``example`` is ``True``,
             a call to :meth:`audbcards.Datacard.player`
-            will store a wavform plot of the example audio file
+            will store a waveform plot of the example audio file
             under
             ``<sphinx_src_dir>/<path>/<dataset-name>/``
         cache_root: cache folder.

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -118,7 +118,7 @@ class Datacard(object):
         If all duration values are the same,
         no distribution plot is created.
 
-        """  # noqa: E501
+        """
         file_name = (
             f"{self.dataset.name}-{self.dataset.version}-file-duration-distribution.png"
         )

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -104,17 +104,32 @@ class Datacard(object):
         containing the mininimum and maximum values
         of files durations.
 
-        If :attr:`audbcards.Datacard.sphinx_src_dir` is set
+        If :attr:`audbcards.Datacard.sphinx_src_dir` is not ``None``
         (e.g. when used in the sphinx extension),
-        an inline image is stored
-        in the sphinx source folder
-        under ``<dataset-name>/<dataset-name>-file-durations.png``
-        and displayed
+        an image is stored in the file
+        ``<dataset-name>-<dataset-version>-file-duration-distribution.png``,
+        which is cached in
+        ``<cache-root>/<dataset-name>/<dataset-version>/``
+        and copied to the sphinx source folder
+        under
+        ``<dataset-name>/``.
+        The image is displayed inline
         between the minimum and maximum values.
         If all duration values are the same,
         no distribution plot is created.
 
-        """
+        """  # noqa: E501
+        file_name = (
+            f"{self.dataset.name}-{self.dataset.version}-file-duration-distribution.png"
+        )
+        # Cache is organized as `<cache_root>/<name>/<version>/`
+        cache_file = audeer.path(
+            self.cache_root,
+            self.dataset.name,
+            self.dataset.version,
+            file_name,
+        )
+
         min_ = 0
         max_ = 0
         unit = "s"
@@ -132,17 +147,8 @@ class Datacard(object):
 
         # Save distribution plot
         if self.sphinx_src_dir is not None:
-            file_name = f"{self.dataset.name}-{self.dataset.version}-file-durations.png"
-
             # Plot distribution to cache,
             # if not found there already.
-            # Cache is organized as `<cache_root>/<name>/<version>/`
-            cache_file = audeer.path(
-                self.cache_root,
-                self.dataset.name,
-                self.dataset.version,
-                file_name,
-            )
             if not os.path.exists(cache_file):
                 audeer.mkdir(os.path.dirname(cache_file))
                 self._plot_distribution(durations)

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -211,7 +211,7 @@ class Datacard(object):
         )
         cache_example_media = audeer.path(
             cache_folder,
-            "player-media",
+            f"{self.dataset.name}-{self.dataset.version}-player-media",
             self.dataset.example_media,
         )
         cache_waveform_file = audeer.path(

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -220,6 +220,26 @@ class Datacard(object):
             audeer.mkdir(os.path.dirname(cache_example_media))
             shutil.copy(media, cache_example_media)
 
+        def plot_waveform_to_cache(cache_example_media: str, cache_waveform_file: str):
+            r"""Plot waveform of example media to cache.
+
+            Args:
+                cache_example_media: full path to media file in cache
+                cache_waveform_file: full path to waveform file in cache
+
+            """
+            signal, sampling_rate = audiofile.read(
+                cache_example_media,
+                always_2d=True,
+            )
+            audeer.mkdir(os.path.dirname(cache_waveform_file))
+            plt.figure(figsize=[3, 0.5])
+            ax = plt.subplot(111)
+            audplot.waveform(signal[0, :], ax=ax)
+            set_plot_margins()
+            plt.savefig(cache_waveform_file)
+            plt.close()
+
         # Cache is organized as `<cache_root>/<name>/<version>/`
         cache_folder = audeer.path(
             self.cache_root,
@@ -242,17 +262,7 @@ class Datacard(object):
                 load_media_to_cache(cache_example_media)
 
             if not os.path.exists(cache_waveform_file):
-                signal, sampling_rate = audiofile.read(
-                    cache_example_media,
-                    always_2d=True,
-                )
-                audeer.mkdir(os.path.dirname(cache_waveform_file))
-                plt.figure(figsize=[3, 0.5])
-                ax = plt.subplot(111)
-                audplot.waveform(signal[0, :], ax=ax)
-                set_plot_margins()
-                plt.savefig(cache_waveform_file)
-                plt.close()
+                plot_waveform_to_cache(cache_example_media, cache_waveform_file)
 
             plot_dst_dir = audeer.path(
                 self.sphinx_src_dir,

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -176,7 +176,7 @@ class Datacard(object):
 
         If :attr:`audbcards.Datacard.sphinx_build_dir`
         or :attr:`audbcards.Datacard.sphinx_src_dir`
-        are not ``None``,
+        is not ``None``,
         an example media file is cached in the folder
         ``<dataset-name>-<dataset-version>-player-media/``
         inside

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -226,22 +226,14 @@ class Datacard(object):
                 cache_example_media: full path to media file in cache
 
             """
-            # Path to corresponding media files in audb
-            media_src_dir = (
-                f"{audb.default_cache_root()}/"
-                f"{audb.flavor_path(self.dataset.name, self.dataset.version)}"
-            )
-            audb.load_media(
+            media = audb.load_media(
                 self.dataset.name,
                 self.dataset.example_media,
                 version=self.dataset.version,
                 verbose=False,
-            )
+            )[0]
             audeer.mkdir(os.path.dirname(cache_example_media))
-            shutil.copy(
-                os.path.join(media_src_dir, self.dataset.example_media),
-                cache_example_media,
-            )
+            shutil.copy(media, cache_example_media)
 
         # Add plot of waveform
         if self.sphinx_src_dir is not None:

--- a/audbcards/core/templates/datacard_example.j2
+++ b/audbcards/core/templates/datacard_example.j2
@@ -5,6 +5,8 @@ Example
 
 
 :file:`{{ example_media }}`
+{% if player %}
 
 {{ player }}
+{% endif %}
 {% endif %}

--- a/audbcards/core/templates/datacard_example.j2
+++ b/audbcards/core/templates/datacard_example.j2
@@ -1,10 +1,10 @@
-{% if example is not none %}
+{% if example_media is not none %}
 
 Example
 {% for n in range("Example"|length) %}^{% endfor %}
 
 
-:file:`{{ example }}`
+:file:`{{ example_media }}`
 
 {{ player }}
 {% endif %}

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -1,3 +1,5 @@
+.. |medium_db-1.0.0-file-duration-distribution| image:: ./medium_db/medium_db-1.0.0-file-duration-distribution.png
+
 .. _datasets-medium_db:
 
 medium_db
@@ -16,7 +18,7 @@ channel       1
 sampling rate 8000
 bit depth     16
 duration      0 days 00:05:02
-files         2, duration distribution: 1.0 s .. 301.0 s
+files         2, duration distribution: 1.0 s |medium_db-1.0.0-file-duration-distribution| 301.0 s
 repository    `data-local <.../data-local/medium_db>`__
 published     2023-04-05 by author
 ============= ======================

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -31,7 +31,7 @@ Example
 
 :file:`data/f0.wav`
 
-.. image:: ./medium_db/medium_db.png
+.. image:: ./medium_db/medium_db-1.0.0-player.png
 
 .. raw:: html
 

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -31,7 +31,7 @@ Example
 
 :file:`data/f0.wav`
 
-.. image:: ./medium_db/medium_db-1.0.0-player.png
+.. image:: ./medium_db/medium_db-1.0.0-player-waveform.png
 
 .. raw:: html
 

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -1,9 +1,7 @@
 import os
-import posixpath
 import re
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pytest
 
 import audeer
@@ -45,38 +43,6 @@ def test_datacard(db, cache, request):
 
 
 @pytest.mark.parametrize(
-    "db",
-    [
-        "medium_db",
-    ],
-)
-def test_datacard_example_media(db, cache, request):
-    r"""Test Datacard.example_media.
-
-    It checks that the desired audio file
-    is selected as example.
-
-    """
-    db = request.getfixturevalue(db)
-    dataset = audbcards.Dataset(db.name, pytest.VERSION, cache_root=cache)
-    datacard = audbcards.Datacard(dataset)
-
-    # Relative path to audio file from database
-    # as written in the dependencies table,
-    # for example data/file.wav
-    durations = [d.total_seconds() for d in db.files_duration(db.files)]
-    median_duration = np.median([d for d in durations if 0.5 < d < 300])
-    expected_example_index = min(
-        range(len(durations)), key=lambda n: abs(durations[n] - median_duration)
-    )
-    expected_example = audeer.path(db.files[expected_example_index]).replace(
-        os.sep, posixpath.sep
-    )
-    expected_example = "/".join(expected_example.split("/")[-2:])
-    assert datacard.example_media == expected_example
-
-
-@pytest.mark.parametrize(
     "db, expected_min, expected_max",
     [
         ("bare_db", 0, 0),
@@ -113,7 +79,7 @@ def test_datacard_file_duration_distribution(
         build_dir,
         datacard.path,
         db.name,
-        f"{db.name}-file-durations.png",
+        f"{db.name}-{pytest.VERSION}-file-durations.png",
     )
     assert not os.path.exists(image_file)
     if expected_min == expected_max:
@@ -129,7 +95,9 @@ def test_datacard_file_duration_distribution(
     if expected_min != expected_max:
         assert os.path.exists(image_file)
         expected_distribution_str = (
-            f"{expected_min:.1f} s |{db.name}-file-durations| {expected_max:.1f} s"
+            f"{expected_min:.1f} s "
+            f"|{db.name}-{pytest.VERSION}-file-durations| "
+            f"{expected_max:.1f} s"
         )
     assert expected_distribution_str == distribution_str
 
@@ -164,13 +132,13 @@ def test_datacard_player(tmpdir, db, cache, request):
         build_dir,
         datacard.path,
         db.name,
-        datacard.example_media,
+        datacard.dataset.example_media,
     )
     image_file = audeer.path(
         src_dir,
         datacard.path,
         db.name,
-        f"{db.name}.png",
+        f"{db.name}-{pytest.VERSION}-player.png",
     )
     assert not os.path.exists(media_file)
     assert not os.path.exists(image_file)
@@ -178,7 +146,7 @@ def test_datacard_player(tmpdir, db, cache, request):
     # Set sphinx src and build dir and execute again
     datacard.sphinx_build_dir = build_dir
     datacard.sphinx_src_dir = src_dir
-    player_str = datacard.player(datacard.example_media)
+    player_str = datacard.player()
     assert os.path.exists(media_file)
     assert os.path.exists(image_file)
 
@@ -201,11 +169,11 @@ def test_datacard_player(tmpdir, db, cache, request):
 
     # Append audio to the expected player_str
     expected_player_str = (
-        f".. image:: ./{db.name}/{db.name}.png\n"
+        f".. image:: ./{db.name}/{db.name}-{pytest.VERSION}-player.png\n"
         "\n"
         ".. raw:: html\n"
         "\n"
-        f'    <p><audio controls src="./{db.name}/{datacard.example_media}">'
+        f'    <p><audio controls src="./{db.name}/{datacard.dataset.example_media}">'
         f"</audio></p>"
     )
     # Check if the generated player_str and the expected matches

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -79,7 +79,7 @@ def test_datacard_file_duration_distribution(
         build_dir,
         datacard.path,
         db.name,
-        f"{db.name}-{pytest.VERSION}-file-durations.png",
+        f"{db.name}-{pytest.VERSION}-file-duration-distribution.png",
     )
     assert not os.path.exists(image_file)
     if expected_min == expected_max:
@@ -96,7 +96,7 @@ def test_datacard_file_duration_distribution(
         assert os.path.exists(image_file)
         expected_distribution_str = (
             f"{expected_min:.1f} s "
-            f"|{db.name}-{pytest.VERSION}-file-durations| "
+            f"|{db.name}-{pytest.VERSION}-file-duration-distribution| "
             f"{expected_max:.1f} s"
         )
     assert expected_distribution_str == distribution_str

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -21,11 +21,18 @@ from audbcards.core.utils import set_plot_margins
         "medium_db",
     ],
 )
-def test_datacard(db, cache, request):
+def test_datacard(tmpdir, db, cache, request):
     """Test datacard creation from jinja2 templates."""
     db = request.getfixturevalue(db)
     dataset = audbcards.Dataset(db.name, pytest.VERSION, cache_root=cache)
     datacard = audbcards.Datacard(dataset)
+
+    # Set sphinx src and build dir
+    build_dir = audeer.mkdir(tmpdir, "build", "html")
+    src_dir = audeer.mkdir(tmpdir, "docs")
+    datacard.sphinx_build_dir = build_dir
+    datacard.sphinx_src_dir = src_dir
+
     content = datacard._render_template()
     content = content.rstrip()
     expected_content = load_rendered_template(db.name)
@@ -125,6 +132,7 @@ def test_datacard_player(tmpdir, db, cache, request):
 
     # Execute player
     # without specifying sphinx src and build dirs
+    expected_player_str = ""
     player_str = datacard.player()
     build_dir = audeer.mkdir(tmpdir, "build", "html")
     src_dir = audeer.mkdir(tmpdir, "docs")
@@ -142,13 +150,49 @@ def test_datacard_player(tmpdir, db, cache, request):
     )
     assert not os.path.exists(media_file)
     assert not os.path.exists(image_file)
+    assert player_str == expected_player_str
 
-    # Set sphinx src and build dir and execute again
+    # With sphinx source dir
+    expected_player_str = (
+        f".. image:: ./{db.name}/{db.name}-{pytest.VERSION}-player-waveform.png\n\n"
+    )
+    datacard.sphinx_src_dir = src_dir
+    player_str = datacard.player()
+    assert not os.path.exists(media_file)
+    assert os.path.exists(image_file)
+    assert player_str == expected_player_str
+    os.remove(image_file)
+
+    # With sphinx build dir
+    expected_player_str = (
+        ".. raw:: html\n"
+        "\n"
+        f'    <p><audio controls src="./{db.name}/{datacard.dataset.example_media}">'
+        f"</audio></p>"
+    )
+    datacard.sphinx_src_dir = None
+    datacard.sphinx_build_dir = build_dir
+    player_str = datacard.player()
+    assert os.path.exists(media_file)
+    assert not os.path.exists(image_file)
+    assert player_str == expected_player_str
+    os.remove(media_file)
+
+    # With sphinx source dir and build dir
+    expected_player_str = (
+        f".. image:: ./{db.name}/{db.name}-{pytest.VERSION}-player-waveform.png\n"
+        "\n"
+        ".. raw:: html\n"
+        "\n"
+        f'    <p><audio controls src="./{db.name}/{datacard.dataset.example_media}">'
+        f"</audio></p>"
+    )
     datacard.sphinx_build_dir = build_dir
     datacard.sphinx_src_dir = src_dir
     player_str = datacard.player()
     assert os.path.exists(media_file)
     assert os.path.exists(image_file)
+    assert expected_player_str == player_str
 
     # Expected waveform plot
     signal, sampling_rate = audiofile.read(
@@ -166,18 +210,6 @@ def test_datacard_player(tmpdir, db, cache, request):
     # Check if generated images are exactly the same (pixel-wise)
     waveform = open(image_file, "rb").read()
     assert waveform == expected_waveform
-
-    # Append audio to the expected player_str
-    expected_player_str = (
-        f".. image:: ./{db.name}/{db.name}-{pytest.VERSION}-player-waveform.png\n"
-        "\n"
-        ".. raw:: html\n"
-        "\n"
-        f'    <p><audio controls src="./{db.name}/{datacard.dataset.example_media}">'
-        f"</audio></p>"
-    )
-    # Check if the generated player_str and the expected matches
-    assert expected_player_str == player_str
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -138,7 +138,7 @@ def test_datacard_player(tmpdir, db, cache, request):
         src_dir,
         datacard.path,
         db.name,
-        f"{db.name}-{pytest.VERSION}-player.png",
+        f"{db.name}-{pytest.VERSION}-player-waveform.png",
     )
     assert not os.path.exists(media_file)
     assert not os.path.exists(image_file)
@@ -169,7 +169,7 @@ def test_datacard_player(tmpdir, db, cache, request):
 
     # Append audio to the expected player_str
     expected_player_str = (
-        f".. image:: ./{db.name}/{db.name}-{pytest.VERSION}-player.png\n"
+        f".. image:: ./{db.name}/{db.name}-{pytest.VERSION}-player-waveform.png\n"
         "\n"
         ".. raw:: html\n"
         "\n"


### PR DESCRIPTION
Add caching for results (e.g. PNG files) generated by `audbcards.Datacard`.

To achieve this, I did the following:
* Move `audbcards.Datacard.example_media` to `audbcards.Dataset.example_media` as it requires access to the dependency table (`audbcards.Dataset.deps`), and hence it is better suited to be cached as part of `audbcards.Dataset`.
* Added `cache_root` argument to `audbcards.Datacard`. It uses per default the same folder as `audbcards.Dataset`.
* Cache the resulting plot of `audbcards.Datacard.file_duration_distribution()` in the cache folder.
* Cache the media file and resulting plot from `audbcards.Datacard.player()` in the cache folder.

The structure of the stored cache files is (shown by the example for `emodb`):

```bash
$ tree ~/.cache/audbcards/emodb
.../.cache/audbcards/emodb
└── 1.4.1
    ├── emodb-1.4.1-file-duration-distribution.png
    ├── emodb-1.4.1-player-media
    │   └── wav
    │       └── 13b09La.wav
    ├── emodb-1.4.1-player-waveform.png
    └── emodb-1.4.1.pkl
```

I again tested building the pages for all our datasets and now get:

| branch | fresh build | build from cache |
| --- | --- | --- |
| main | 15 minutes | 2 minutes |
| this branch | 15 minutes | 30 seconds |

whereas now most of the time is spend on compiling the HTML pages, and not on gathering information about the datasets.

---

Updated docstrings:

![image](https://github.com/audeering/audbcards/assets/173624/bbf6919d-2b85-4618-a76a-485b65310696)

![image](https://github.com/audeering/audbcards/assets/173624/29e4a5df-314e-4304-8d84-b289c5b3c29f)

![image](https://github.com/audeering/audbcards/assets/173624/74012399-43a7-4a8b-b5d6-ec4deb370c09)

![image](https://github.com/audeering/audbcards/assets/173624/a0ede8c0-d71c-4f4e-ba8a-4f98e389ffed)
