### PR TITLE
CI: update actions to switch to Node.js 20

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [ '3.10' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache .cache/audbcards
       uses: actions/cache@v3
@@ -31,7 +31,7 @@ jobs:
         key: audb-1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,13 +19,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache .cache/audbcards
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/audbcards
         key: audbcards-1
 
     - name: Cache audb
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb
         key: audb-1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,12 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -69,7 +69,7 @@ jobs:
 
     - name: Create release on Github
       id: create_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
             tasks: tests
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
As discussed at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, we need to update all Github Actions that are still using Node.js 16.

This can also be seen when inspecting a [random Actions page](https://github.com/audeering/audbackend/actions/runs/8448176848?pr=200):

![image](https://github.com/audeering/audbackend/assets/173624/6364b924-9fc0-4087-9815-47b576890246)

We fix this here by updating to:

* actions/checkout@v4
* actions/cache@v4
* actions/setup-python@v5
* codecov/codecov-action@v4
* softprops/action-gh-release@v2