### PR TITLE
DOC: exclude Dataset.prop

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -523,12 +523,12 @@ class Dataset(object):
 
     # Copy attributes and methods
     # to include in documentation
-    for prop in [
+    for _prop in [  # use private variable `_prop` to avoid inclusion in API doc
         name
         for name, value in inspect.getmembers(_Dataset)
         if isinstance(value, functools.cached_property) and not name.startswith("_")
     ]:
-        vars()[prop] = getattr(_Dataset, prop)
+        vars()[_prop] = getattr(_Dataset, _prop)
 
     @staticmethod
     def _map_iso_languages(*args):


### PR DESCRIPTION
Closes #85 

This makes sure the class variable `audbcards.Dataset.props` is not documented in the API docs, by renaming it to `_props`.