### PR TITLE
Depend on audbackend>=2.0.0

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -109,7 +109,7 @@ class _Dataset:
             pickle.dump(obj, f, protocol=4)
 
     @property
-    def backend(self) -> audbackend.Backend:
+    def backend(self) -> audbackend.interface.Base:
         r"""Dataset backend object."""
         if not hasattr(self, "_backend"):  # when loaded from cache
             self._backend = self._load_backend()
@@ -419,16 +419,11 @@ class _Dataset:
         )
         return props
 
-    def _load_backend(self) -> audbackend.Backend:
-        r"""Load backend containing dataset."""
-        backend = audbackend.access(
-            name=self.repository_object.backend,
-            host=self.repository_object.host,
-            repository=self.repository,
-        )
-        if isinstance(backend, audbackend.Artifactory):
-            backend._use_legacy_file_structure()
-        return backend
+    def _load_backend(self) -> audbackend.interface.Base:
+        r"""Load backend object containing dataset."""
+        backend_interface = self.repository_object()
+        backend_interface.backend.open()
+        return backend_interface
 
     def _load_dependencies(self) -> audb.Dependencies:
         r"""Load dataset dependencies."""

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -424,7 +424,6 @@ class _Dataset:
     def _load_backend(self) -> audbackend.interface.Base:
         r"""Load backend object containing dataset."""
         backend_interface = self.repository_object.create_backend_interface()
-        # backend_interface.backend.open()
         return backend_interface
 
     def _load_dependencies(self) -> audb.Dependencies:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -109,7 +109,7 @@ class _Dataset:
             pickle.dump(obj, f, protocol=4)
 
     @property
-    def backend(self) -> audbackend.interface.Base:
+    def backend(self) -> typing.Type[audbackend.interface.Base]:
         r"""Dataset backend object."""
         if not hasattr(self, "_backend"):  # when loaded from cache
             self._backend = self._load_backend()
@@ -421,7 +421,7 @@ class _Dataset:
         )
         return props
 
-    def _load_backend(self) -> audbackend.interface.Base:
+    def _load_backend(self) -> typing.Type[audbackend.interface.Base]:
         r"""Load backend object containing dataset."""
         backend_interface = self.repository_object.create_backend_interface()
         return backend_interface

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -279,14 +279,16 @@ class _Dataset:
     @functools.cached_property
     def publication_date(self) -> str:
         r"""Date dataset was uploaded to repository."""
-        path = self.backend.join("/", self.name, "db.yaml")
-        return self.backend.date(path, self.version)
+        with self.backend.backend:
+            path = self.backend.join("/", self.name, "db.yaml")
+            return self.backend.date(path, self.version)
 
     @functools.cached_property
     def publication_owner(self) -> str:
         r"""User who uploaded dataset to repository."""
-        path = self.backend.join("/", self.name, "db.yaml")
-        return self.backend.owner(path, self.version)
+        with self.backend.backend:
+            path = self.backend.join("/", self.name, "db.yaml")
+            return self.backend.owner(path, self.version)
 
     @functools.cached_property
     def repository(self) -> str:
@@ -421,8 +423,8 @@ class _Dataset:
 
     def _load_backend(self) -> audbackend.interface.Base:
         r"""Load backend object containing dataset."""
-        backend_interface = self.repository_object()
-        backend_interface.backend.open()
+        backend_interface = self.repository_object.create_backend_interface()
+        # backend_interface.backend.open()
         return backend_interface
 
     def _load_dependencies(self) -> audb.Dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audb >=1.6.0',
-    'audbackend >=1.0.1',
+    'audb @ git+https://github.com/audeering/audb.git@audbackend-2.0.0',
     'audplot >=1.4.6',
     'jinja2',
     'pandas >=2.1.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audb @ git+https://github.com/audeering/audb.git@audbackend-2.0.0',
+    'audb >=1.7.0',
     'audplot >=1.4.6',
     'jinja2',
     'pandas >=2.1.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def audb_cache(tmpdir, scope="session", autouse=True):
     """Local audb cache folder."""
     cache = audeer.mkdir(audeer.path(tmpdir, "audb-cache"))
     audb.config.CACHE_ROOT = cache
-    audb.config.SHARED_CACHE = cache
+    audb.config.SHARED_CACHE_ROOT = cache
 
 
 @pytest.fixture

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -65,7 +65,7 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
         pytest.VERSION,
         cache_root=dataset_cache,
     )
-    backend_interface = repository()
+    backend_interface = repository.create_backend_interface()
 
     # __init__
     assert dataset.name == db.name
@@ -425,7 +425,7 @@ def test_dataset_cache_loading(audb_cache, tmpdir, repository, db, request):
         version=pytest.VERSION,
         cache_root=audb_cache,
     )
-    backend_interface = repository()
+    backend_interface = repository.create_backend_interface()
     with backend_interface.backend:
         header = audb.info.header(
             db.name,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 
 import audb
-import audbackend
 import audeer
 import audformat
 import audiofile
@@ -66,17 +65,16 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
         pytest.VERSION,
         cache_root=dataset_cache,
     )
-    backend = audbackend.access(
-        name=repository.backend,
-        host=repository.host,
-        repository=repository.name,
-    )
+    backend_interface = repository()
 
     # __init__
     assert dataset.name == db.name
     assert dataset.version == pytest.VERSION
     assert dataset.repository_object == repository
-    assert dataset.backend == backend
+    with backend_interface.backend:
+        # Compare only string,
+        # as backends are not identical
+        assert str(dataset.backend) == str(backend_interface)
     expected_header = audb.info.header(
         db.name,
         version=pytest.VERSION,
@@ -146,19 +144,20 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
         expected_license_link = db.license_url
     assert dataset.license_link == expected_license_link
 
-    # publication_date:
-    expected_publication_date = backend.date(
-        backend.join("/", db.name, "db.yaml"),
-        pytest.VERSION,
-    )
-    assert dataset.publication_date == expected_publication_date
+    with backend_interface.backend:
+        # publication_date:
+        expected_publication_date = backend_interface.date(
+            backend_interface.join("/", db.name, "db.yaml"),
+            pytest.VERSION,
+        )
+        assert dataset.publication_date == expected_publication_date
 
-    # publication_owner
-    expected_publication_owner = backend.owner(
-        backend.join("/", db.name, "db.yaml"),
-        pytest.VERSION,
-    )
-    assert dataset.publication_owner == expected_publication_owner
+        # publication_owner
+        expected_publication_owner = backend_interface.owner(
+            backend_interface.join("/", db.name, "db.yaml"),
+            pytest.VERSION,
+        )
+        assert dataset.publication_owner == expected_publication_owner
 
     # repository
     assert dataset.repository == repository.name
@@ -426,21 +425,20 @@ def test_dataset_cache_loading(audb_cache, tmpdir, repository, db, request):
         version=pytest.VERSION,
         cache_root=audb_cache,
     )
-    backend = audbackend.access(
-        name=repository.backend,
-        host=repository.host,
-        repository=repository.name,
-    )
-    header = audb.info.header(
-        db.name,
-        version=pytest.VERSION,
-        load_tables=True,
-        cache_root=audb_cache,
-    )
-    assert dataset.backend == backend
-    assert dataset.deps == deps
-    # The dataset header is a not fully loaded `audformat.Database` object,
-    # so we cannot directly use `audformat.Database.__eq__()`
-    # to compare it.
-    assert str(dataset.header) == str(header)
-    assert dataset.repository_object == repository
+    backend_interface = repository()
+    with backend_interface.backend:
+        header = audb.info.header(
+            db.name,
+            version=pytest.VERSION,
+            load_tables=True,
+            cache_root=audb_cache,
+        )
+        # Compare only string representation,
+        # as objects are not identical
+        assert str(dataset.backend) == str(backend_interface)
+        assert dataset.deps == deps
+        # The dataset header is a not fully loaded `audformat.Database` object,
+        # so we cannot directly use `audformat.Database.__eq__()`
+        # to compare it.
+        assert str(dataset.header) == str(header)
+        assert dataset.repository_object == repository


### PR DESCRIPTION
Updates the code to use the new API of `audbackend` 2.0.0.

In addition, it fixes the setting of `audb` shared cache root in `tests/conftests.py`.
There we used
```python
audb.config.SHARED_CACHE = cache
```
instead of the correct
```python
audb.config.SHARED_CACHE_ROOT = cache
```