### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.9'
             tasks: tests
+          - os: ubuntu-latest
+            python-version: '3.11'
+            tasks: tests
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'


### PR DESCRIPTION
Runs tests for Python 3.11 in CI, and adds Python 3.11 as supported version in `pyproject.toml`.

This was suggested in https://github.com/audeering/audbcards/pull/84#pullrequestreview-2045274633