### PR TITLE
CI: update publish actions to use Node.js 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       run: python -m sphinx docs/ build/html -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/html


### PR DESCRIPTION
In https://github.com/audeering/audbcards/pull/86 I forgot to update `peaceiris/actions-gh-pages`.