### PR TITLE
Skip Dataset.example_media for large archives

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -199,6 +199,9 @@ class _Dataset:
         from all files in the dataset
         with a duration
         between 0.5 s and 300 s.
+        In addition,
+        the media file needs to be stored in an archive
+        with less than 100 media files.
         If no media file meets this criterium,
         ``None`` is returned instead.
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -223,9 +223,10 @@ class _Dataset:
         )
         # Ensure we don't have too many other files
         # in the archive containing the selected file
-        selected_archive = self.deps.archives[index]
+        archives = self.deps().archive
+        selected_archive = archives[index]
         number_of_files = len(
-            [archive for archive in self.deps.archives if archive == selected_archive]
+            [archive for archive in archives if archive == selected_archive]
         )
         selected_media = None
         if number_of_files < 100:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -221,7 +221,16 @@ class _Dataset:
             range(len(durations)),
             key=lambda n: abs(durations[n] - selected_duration),
         )
-        return self.deps.media[index]
+        # Ensure we don't have too many other files
+        # in the archive containing the selected file
+        selected_archive = self.deps.archives[index]
+        number_of_files = len(
+            [archive for archive in self.deps.archives if archive == selected_archive]
+        )
+        selected_media = None
+        if number_of_files < 100:
+            selected_media = self.deps.media[index]
+        return selected_media
 
     @functools.cached_property
     def files(self) -> int:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -227,7 +227,7 @@ class _Dataset:
         # Ensure we don't have too many other files in the archive
         # containing the selected file
         archives = self.deps().archive
-        selected_archive = archives[index]
+        selected_archive = archives.iloc[index]
         number_of_files = len(
             [archive for archive in archives if archive == selected_archive]
         )

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -221,8 +221,8 @@ class _Dataset:
             range(len(durations)),
             key=lambda n: abs(durations[n] - selected_duration),
         )
-        # Ensure we don't have too many other files
-        # in the archive containing the selected file
+        # Ensure we don't have too many other files in the archive
+        # containing the selected file
         archives = self.deps().archive
         selected_archive = archives[index]
         number_of_files = len(


### PR DESCRIPTION
In `audbcards.Dataset.example_media` we limit the length of the selected example audio file to 300 s in order to avoid downloading too large files. With `audb` you are able to publish media files in the same archive as other media files, which means you might still have to download a large archive file. To limit this to some extend, `audbcards.Dataset.example_media` returns now `None`, if the selected media file is stored in an archive with more than 99 files.

![image](https://github.com/user-attachments/assets/87858057-41e4-4fd9-90f0-a074220f09e7)

For the next example to work, ensure you have cleaned your cache with:
```bash
$ rm -rf ~/.cache/audbcards/imda-nsc-read-speech-random/
```

```python
>>> ds = audbcards.Dataset("emodb", "1.4.1")
>>> ds.example_media
'wav/13b09La.wav'

>>> ds.deps.archive("wav/13b09La.wav")
'26ec06e9-d0aa-88f9-fd4d-156bbaf1646e'

>>> df = ds.deps()
>>> len(df[df.archive == "26ec06e9-d0aa-88f9-fd4d-156bbaf1646e"])
1

>>> ds = audbcards.Dataset("imda-nsc-read-speech-random", "2.6.0")  # requires access to internal server
>>> ds.example_media

>>> # before it was part2/channel0/speaker2001/session0/020010047.wav
>>> ds.deps.archive("part2/channel0/speaker2001/session0/020010047.wav")
'channel0-speaker2001'

>>> df = ds.deps()
>>> len(df[df.archive == "channel0-speaker2001"])
875

```