### PR TITLE
TST: use temporary cache for audbcards.Datacard

### DIFF
--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -25,7 +25,7 @@ def test_datacard(tmpdir, db, cache, request):
     """Test datacard creation from jinja2 templates."""
     db = request.getfixturevalue(db)
     dataset = audbcards.Dataset(db.name, pytest.VERSION, cache_root=cache)
-    datacard = audbcards.Datacard(dataset)
+    datacard = audbcards.Datacard(dataset, cache_root=cache)
 
     # Set sphinx src and build dir
     build_dir = audeer.mkdir(tmpdir, "build", "html")
@@ -75,7 +75,7 @@ def test_datacard_file_duration_distribution(
     dataset = audbcards.Dataset(db.name, pytest.VERSION, cache_root=cache)
 
     datacard_path = audeer.mkdir(tmpdir, "datasets")
-    datacard = audbcards.Datacard(dataset, path=datacard_path)
+    datacard = audbcards.Datacard(dataset, path=datacard_path, cache_root=cache)
 
     # Without specifying sphinx src and build dirs,
     # we do not expect a PNG file
@@ -128,7 +128,7 @@ def test_datacard_player(tmpdir, db, cache, request):
     dataset = audbcards.Dataset(db.name, pytest.VERSION, cache_root=cache)
 
     datacard_path = audeer.mkdir(tmpdir, "datasets")
-    datacard = audbcards.Datacard(dataset, path=datacard_path)
+    datacard = audbcards.Datacard(dataset, path=datacard_path, cache_root=cache)
 
     # Execute player
     # without specifying sphinx src and build dirs


### PR DESCRIPTION
As discovered in https://github.com/audeering/audbcards/pull/97#issuecomment-2250145521, the temporary cache for `audbcards` was not used when testing `audbcards.Datacard`. This is fixed by this pull request.