### PR TITLE
Show example video as video instead of audio

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -33,7 +33,7 @@ class Datacard(object):
         path: path to folder
             that store datacard files
         example: if ``True``,
-            include an audio example in the data card
+            include an audio or video example in the data card
             showing the waveform of the audio
             and an interactive player
         sphinx_build_dir: build dir of sphinx.
@@ -173,7 +173,7 @@ class Datacard(object):
         return distribution_str
 
     def player(self) -> str:
-        r"""Create an audio player showing the waveform.
+        r"""Create an audio/video player showing the waveform.
 
         If :attr:`audbcards.Datacard.sphinx_build_dir`
         or :attr:`audbcards.Datacard.sphinx_src_dir`
@@ -308,12 +308,15 @@ class Datacard(object):
                 cache_example_media,
                 os.path.join(media_dst_dir, self.dataset.example_media),
             )
-
+            if audiofile.has_video(cache_example_media):
+                media_tag = "video"
+            else:
+                media_tag = "audio"
             player_src = f"./{self.dataset.name}/{self.dataset.example_media}"
             player_str += (
                 ".. raw:: html\n"
                 "\n"
-                f'    <p><audio controls src="{player_src}"></audio></p>'
+                f'    <p><{media_tag} controls src="{player_src}"></{media_tag}></p>'
             )
 
         return player_str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires-python = '>=3.9'
 dependencies = [
     'audb >=1.7.0',
     'audeer >=2.2.0',
+    'audiofile >=1.5.0',
     'audplot >=1.4.6',
     'jinja2',
     'pandas >=2.1.0',


### PR DESCRIPTION
Closes https://github.com/audeering/audbcards/issues/62

Requires https://github.com/audeering/audiofile/pull/153 to be merged first, and a new release of `audiofile`.

The resulting example for `voxceleb2-videos` would be:

![image](https://github.com/user-attachments/assets/739b3aa4-34f1-4c8f-a878-51c374d2a2ca)

Updated docstring of `audbcards.Datacard.player`:

![image](https://github.com/user-attachments/assets/956402f2-c8f6-4ebc-8b38-b4bc88a5b31a)
