### PR TITLE
Ensure video width fits on datacard

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -316,7 +316,8 @@ class Datacard(object):
             player_str += (
                 ".. raw:: html\n"
                 "\n"
-                f'    <p><{media_tag} controls src="{player_src}"></{media_tag}></p>'
+                f'    <p><{media_tag} controls src="{player_src}" '
+                f'style="max-width: 100%;"></{media_tag}></p>'
             )
 
         return player_str

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -316,8 +316,7 @@ class Datacard(object):
             player_str += (
                 ".. raw:: html\n"
                 "\n"
-                f'    <p><{media_tag} controls src="{player_src}" '
-                f'style="max-width: 100%;"></{media_tag}></p>'
+                f'    <p><{media_tag} controls src="{player_src}"></{media_tag}></p>'
             )
 
         return player_str

--- a/audbcards/sphinx/table-preview.css
+++ b/audbcards/sphinx/table-preview.css
@@ -80,3 +80,7 @@ table.preview th {
     /* Use normal font in header row of preview table */
     font-weight: normal !important;
 }
+/* Ensure example video fits onto page */
+#example.section video {
+    max-width: 100%;
+}


### PR DESCRIPTION
Ensure example video fits on datacard by setting its max width to 100% page width.