### PR TITLE
Speedup audbcards.Dataset.segments

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -746,6 +746,7 @@ class _Dataset:
                     self.name,
                     table,
                     version=self.version,
+                    pickle_tables=False,
                     verbose=False,
                 )
                 index = audformat.utils.union([index, df.index])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audb >=1.7.0',
+    'audb >=1.9.0',
     'audeer >=2.2.0',
     'audiofile >=1.5.0',
     'audplot >=1.4.6',


### PR DESCRIPTION
Depend on `audb>1.9.0` to make use of the new `pickle_tables` argument to avoid pickling tables in cache when loading them the first time to calculate the number of segments in `audbcards.Dataset.segments`. If the table is already stored as a pickle file in cache, it will still load the pickled table.