### PR TITLE
Add Dataset.tables_columns and tables_rows

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -775,11 +775,18 @@ class _Dataset:
     def _tables_stats(self) -> typing.Dict[str, dict]:
         """Table information of tables in the dataset.
 
-        It returns a dict per table, containing:
+        Caches table information to improve performance
+        of multiple table-related properties.
+        This property computes and stores statistics for all tables,
+        reducing repeated computations.
+        It significantly improves performance
+        when accessing multiple table properties frequently.
 
-        * ``"columns"``: number of table columns
-        * ``"rows"``: number of table rows
-        * ``"preview"``: preview of table
+        Returns:
+            A dictionary with table names as keys and dictionaries containing:
+            - "columns": number of columns
+            - "rows": number of rows
+            - "preview": table preview (header + first 5 rows)
 
         """
         stats = {}

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -22,7 +22,9 @@ class _Dataset:
     _table_related_cached_properties = [
         "segment_durations",
         "segments",
+        "tables_columns",
         "tables_preview",
+        "tables_rows",
     ]
     """Cached properties relying on table data.
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -511,6 +511,26 @@ class _Dataset:
         return tables
 
     @functools.cached_property
+    def tables_columns(self) -> typing.Dict[str, int]:
+        """Number of columns for each table of the dataset.
+
+        Returns:
+            dictionary with table IDs as keys
+            and number of columns as values
+
+        Examples:
+            >>> ds = Dataset("emodb", "1.4.1")
+            >>> ds.tables_columns["speaker"]
+            3
+
+        """
+        columns = {}
+        for table in list(self.header):
+            df = self._tables[table]
+            columns[table] = len(df.columns)
+        return columns
+
+    @functools.cached_property
     def tables_preview(self) -> typing.Dict[str, typing.List[typing.List[str]]]:
         """Table preview for each table of the dataset.
 

--- a/audbcards/core/templates/datacard_tables.j2
+++ b/audbcards/core/templates/datacard_tables.j2
@@ -41,6 +41,7 @@ Tables
     {% for column in row %}
     <td><p>{{ column }}</p></td>
     {% endfor %}
+    </tr>
     {% endif %}
     {% endfor %}
     </tbody>

--- a/audbcards/core/templates/datacard_tables.j2
+++ b/audbcards/core/templates/datacard_tables.j2
@@ -44,6 +44,7 @@ Tables
     </tr>
     {% endif %}
     {% endfor %}
+    <tr><td><p>{{ tables_rows[row[0]] }} rows</p></td></tr>
     </tbody>
     </table>
 

--- a/audbcards/core/templates/datacard_tables.j2
+++ b/audbcards/core/templates/datacard_tables.j2
@@ -44,7 +44,7 @@ Tables
     </tr>
     {% endif %}
     {% endfor %}
-    <tr><td><p>{{ tables_rows[row[0]] }} {% if tables_rows[row[0]] == 1 %}row{% else %}rows{% endif %} x {{ tables_columns[row[0]] }} {% if tables_columns[row[0]] == 1 %}column{% else %}columns{% endif %}</p></td></tr>
+    <tr><td><p class="table-statistic">{{ tables_rows[row[0]] }} {% if tables_rows[row[0]] == 1 %}row{% else %}rows{% endif %} x {{ tables_columns[row[0]] }} {% if tables_columns[row[0]] == 1 %}column{% else %}columns{% endif %}</p></td></tr>
     </tbody>
     </table>
 

--- a/audbcards/core/templates/datacard_tables.j2
+++ b/audbcards/core/templates/datacard_tables.j2
@@ -44,7 +44,7 @@ Tables
     </tr>
     {% endif %}
     {% endfor %}
-    <tr><td><p>{{ tables_rows[row[0]] }} rows</p></td></tr>
+    <tr><td><p>{{ tables_rows[row[0]] }} {% if tables_rows[row[0]] == 1 %}row{% else %}rows{% endif %} x {{ tables_columns[row[0]] }} {% if tables_columns[row[0]] == 1 %}column{% else %}columns{% endif %}</p></td></tr>
     </tbody>
     </table>
 

--- a/audbcards/sphinx/table-preview.css
+++ b/audbcards/sphinx/table-preview.css
@@ -34,6 +34,10 @@ table.preview td {
     border-top: none;
     border-bottom: none;
 }
+table.preview td p.table-statistic {
+    /* Make "N rows x M columns" smaller */
+    font-size: 90%;
+}
 table.clickable td:not(.expanded-row-content),
 table.clickable th {
     /* Allow to center cell copntent with `margin: auto` */

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -78,7 +78,7 @@ Tables
         <td><p>data/f1.wav</p></td>
         <td><p>1</p></td>
         </tr>
-            <tr><td><p>2 rows</p></td></tr>
+            <tr><td><p>2 rows x 1 column</p></td></tr>
     </tbody>
     </table>
 
@@ -126,7 +126,7 @@ Tables
         <td><p>0 days 00:05:01</p></td>
         <td><p>angry</p></td>
         </tr>
-            <tr><td><p>4 rows</p></td></tr>
+            <tr><td><p>4 rows x 1 column</p></td></tr>
     </tbody>
     </table>
 
@@ -159,7 +159,7 @@ Tables
         <td><p>49</p></td>
         <td><p>male</p></td>
         </tr>
-            <tr><td><p>2 rows</p></td></tr>
+            <tr><td><p>2 rows x 2 columns</p></td></tr>
     </tbody>
     </table>
 

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -73,10 +73,13 @@ Tables
                     <tr>
         <td><p>data/f0.wav</p></td>
         <td><p>0</p></td>
-                    <tr>
+        </tr>
+                <tr>
         <td><p>data/f1.wav</p></td>
         <td><p>1</p></td>
-                </tbody>
+        </tr>
+            <tr><td><p>2 rows</p></td></tr>
+    </tbody>
     </table>
 
     
@@ -104,22 +107,27 @@ Tables
         <td><p>0 days 00:00:00</p></td>
         <td><p>0 days 00:00:00.500000</p></td>
         <td><p>neutral</p></td>
-                    <tr>
+        </tr>
+                <tr>
         <td><p>data/f0.wav</p></td>
         <td><p>0 days 00:00:00.500000</p></td>
         <td><p>0 days 00:00:01</p></td>
         <td><p>neutral</p></td>
-                    <tr>
+        </tr>
+                <tr>
         <td><p>data/f1.wav</p></td>
         <td><p>0 days 00:00:00</p></td>
         <td><p>0 days 00:02:30</p></td>
         <td><p>happy</p></td>
-                    <tr>
+        </tr>
+                <tr>
         <td><p>data/f1.wav</p></td>
         <td><p>0 days 00:02:30</p></td>
         <td><p>0 days 00:05:01</p></td>
         <td><p>angry</p></td>
-                </tbody>
+        </tr>
+            <tr><td><p>4 rows</p></td></tr>
+    </tbody>
     </table>
 
     
@@ -145,11 +153,14 @@ Tables
         <td><p>0</p></td>
         <td><p>23</p></td>
         <td><p>female</p></td>
-                    <tr>
+        </tr>
+                <tr>
         <td><p>1</p></td>
         <td><p>49</p></td>
         <td><p>male</p></td>
-                </tbody>
+        </tr>
+            <tr><td><p>2 rows</p></td></tr>
+    </tbody>
     </table>
 
     

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -78,7 +78,7 @@ Tables
         <td><p>data/f1.wav</p></td>
         <td><p>1</p></td>
         </tr>
-            <tr><td><p>2 rows x 1 column</p></td></tr>
+            <tr><td><p class="table-statistic">2 rows x 1 column</p></td></tr>
     </tbody>
     </table>
 
@@ -126,7 +126,7 @@ Tables
         <td><p>0 days 00:05:01</p></td>
         <td><p>angry</p></td>
         </tr>
-            <tr><td><p>4 rows x 1 column</p></td></tr>
+            <tr><td><p class="table-statistic">4 rows x 1 column</p></td></tr>
     </tbody>
     </table>
 
@@ -159,7 +159,7 @@ Tables
         <td><p>49</p></td>
         <td><p>male</p></td>
         </tr>
-            <tr><td><p>2 rows x 2 columns</p></td></tr>
+            <tr><td><p class="table-statistic">2 rows x 2 columns</p></td></tr>
     </tbody>
     </table>
 

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -59,7 +59,7 @@ Tables
         <td><p>f0.wav</p></td>
         <td><p>0</p></td>
         </tr>
-            <tr><td><p>1 row x 1 column</p></td></tr>
+            <tr><td><p class="table-statistic">1 row x 1 column</p></td></tr>
     </tbody>
     </table>
 

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -58,7 +58,9 @@ Tables
                     <tr>
         <td><p>f0.wav</p></td>
         <td><p>0</p></td>
-                </tbody>
+        </tr>
+            <tr><td><p>1 rows</p></td></tr>
+    </tbody>
     </table>
 
     

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -59,7 +59,7 @@ Tables
         <td><p>f0.wav</p></td>
         <td><p>0</p></td>
         </tr>
-            <tr><td><p>1 rows</p></td></tr>
+            <tr><td><p>1 row x 1 column</p></td></tr>
     </tbody>
     </table>
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -206,11 +206,19 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     assert dataset.tables == expected_tables
 
     # tables_columns
-    expected_tables_columns = {table: len(db[table].df.columns) for table in list(db)}
+    expected_tables_columns = {
+        "files": 1,
+        "segments": 1,
+        "speaker": 2,
+    }
     assert dataset.tables_columns == expected_tables_columns
 
     # tables_rows
-    expected_tables_rows = {table: len(db[table].df) for table in list(db)}
+    expected_tables_rows = {
+        "files": 2,
+        "segments": 4,
+        "speaker": 2,
+    }
     assert dataset.tables_rows == expected_tables_rows
 
     # tables_table

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -206,15 +206,11 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     assert dataset.tables == expected_tables
 
     # tables_columns
-    expected_tables_columns = {}
-    for table_id in list(db):
-        expected_tables_columns[table_id] = len(db[table_id].columns)
+    expected_tables_columns = {table: len(db[table].df.columns) for table in list(db)}
     assert dataset.tables_columns == expected_tables_columns
 
     # tables_rows
-    expected_tables_rows = {}
-    for table_id in list(db):
-        expected_tables_rows[table_id] = len(db[table_id])
+    expected_tables_rows = {table: len(db[table].df) for table in list(db)}
     assert dataset.tables_rows == expected_tables_rows
 
     # tables_table

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -205,6 +205,12 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     expected_tables = list(db)
     assert dataset.tables == expected_tables
 
+    # tables_rows
+    expected_tables_rows = {}
+    for table_id in list(db):
+        expected_tables_rows[table_id] = len(db[table_id])
+    assert dataset.tables_rows == expected_tables_rows
+
     # tables_table
     expected_tables_table = [["ID", "Type", "Columns"]]
     for table_id in list(db):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -205,6 +205,12 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
     expected_tables = list(db)
     assert dataset.tables == expected_tables
 
+    # tables_columns
+    expected_tables_columns = {}
+    for table_id in list(db):
+        expected_tables_columns[table_id] = len(db[table_id].columns)
+    assert dataset.tables_columns == expected_tables_columns
+
     # tables_rows
     expected_tables_rows = {}
     for table_id in list(db):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -49,12 +49,17 @@ def test_dataset_property_scope(tmpdir, db, request):
 
 
 @pytest.mark.parametrize(
-    "db, expected_schemes_table, expected_tables_table, "
-    "expected_tables_columns, expected_tables_rows, "
+    "db, "
+    "expected_description, "
+    "expected_schemes_table, "
+    "expected_tables_table, "
+    "expected_tables_columns, "
+    "expected_tables_rows, "
     "expected_segment_durations",
     [
         (
             "bare_db",
+            "",
             [[]],
             [["ID", "Type", "Columns"]],
             {},
@@ -63,6 +68,7 @@ def test_dataset_property_scope(tmpdir, db, request):
         ),
         (
             "minimal_db",
+            "Minimal database.",
             [[]],
             [["ID", "Type", "Columns"], ["files", "filewise", "speaker"]],
             {"files": 1},
@@ -71,6 +77,7 @@ def test_dataset_property_scope(tmpdir, db, request):
         ),
         (
             "medium_db",
+            "Medium database. | Some description |.",
             [
                 ["ID", "Dtype", "Min", "Labels", "Mappings"],
                 ["age", "int", 0, "", ""],
@@ -96,6 +103,7 @@ def test_dataset(
     repository,
     request,
     db,
+    expected_description,
     expected_schemes_table,
     expected_tables_table,
     expected_tables_columns,
@@ -231,15 +239,6 @@ def test_dataset(
     assert dataset.segments == expected_segments
 
     # short_description
-    max_desc_length = 150
-    if db.description is None:
-        expected_description = ""
-    else:
-        expected_description = (
-            db.description
-            if (len(db.description) < max_desc_length)
-            else f"{db.description[:max_desc_length - 3]}..."
-        )
     assert dataset.short_description == expected_description
 
     # tables


### PR DESCRIPTION
Closes #111 

This adds the cached properties `audbcards.Dataset.tables_columns` and `audbcards.Dataset.tables_rows`,
which return the number of columns and rows for each table of a dataset.

![image](https://github.com/user-attachments/assets/61b9e64b-d21d-4c11-82a8-cb7c2e55d0bd)

![image](https://github.com/user-attachments/assets/3f87b24c-160a-466b-b601-6afaff5d7bfb)


In addition, it uses those in the HTML table preview:

![image](https://github.com/user-attachments/assets/247c2d9a-7934-4b02-8d5d-8c5f2c459c04)


Under the hood, it adds the private cached property `audbcards.Dataset._tables_stats()` to avoid loading the tables multiple times.

## Summary by Sourcery

Add new cached properties `tables_columns` and `tables_rows` to the `audbcards.Dataset` class to provide table dimensions, and enhance the HTML table preview to display these dimensions. Update tests to cover the new properties.

New Features:
- Introduce cached properties `tables_columns` and `tables_rows` in the `audbcards.Dataset` class to provide the number of columns and rows for each table in a dataset.

Enhancements:
- Enhance the HTML table preview by displaying the number of rows and columns for each table.

Tests:
- Update tests to include validation for the new `tables_columns` and `tables_rows` properties.