### PR TITLE
TST: fix ISO language tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 audb >=1.6.5  # for audb.Dependencies.__eq__()
 audeer >=1.21.0
+audformat >=1.3.1  # for ISO language test
 pytest
 tabulate

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -234,15 +234,15 @@ def test_dataset(audb_cache, tmpdir, repository, db, request):
                 "Egyptian Arabic",
                 "Libyan Arabic",
                 "Moroccan Arabic",
-                "North Levantine Arabic",
+                "Levantine Arabic",
             ],
-            ["arz", "ary", "apc", "ayl", "arq"],
+            ["arq", "arz", "ayl", "ary", "apc"],
         ),
         (["Algerian Arabic"], ["arq"]),
         (["Egyptian Arabic"], ["arz"]),
         (["Libyan Arabic"], ["ayl"]),
-        (["North Levantine Arabic"], ["apc"]),
         (["Moroccan Arabic"], ["ary"]),
+        (["Levantine Arabic"], ["apc"]),
     ],
 )
 def test_iso_language_mappings(languages, iso_languages_expected):


### PR DESCRIPTION
Adjust tests for ISO languages to the changes introduced by the new iso369 library in `audformat` 1.3.1.

Before we specified, that `"North Levantine Arabic"` should map to `"apc"`, but the correct language name is `"Levantine Arabic"`, compare https://iso639-3.sil.org/code/apc.

Maybe this was updated at some place by ISO369, as they still have `"South Levantine Arabic"`, but marked it as deprecated.