### PR TITLE
Remove URL from Dataset.repositories

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -989,9 +989,7 @@ def create_datasets_page(
         )
         for dataset in datasets
     ]
-    repositories = [
-        f"`{repo.name} <{repo.host}>`__" for repo in audb.config.REPOSITORIES
-    ]
+    repositories = [f"{repo.name}" for repo in audb.config.REPOSITORIES]
     content = {
         "data": data,
         "name": audeer.basename_wo_ext(rst_file),

--- a/audbcards/core/templates/datasets.j2
+++ b/audbcards/core/templates/datasets.j2
@@ -10,7 +10,7 @@ repositories
 {% else %}
 repository
 {% endif %}
-{{ repositories|join(', ') }}.
+**{{ repositories|join('**, **') }}**.
 For each dataset, the latest version is shown.
 
 {% if data|length > 0 %}


### PR DESCRIPTION
For some repositories, like S3, the URL of a repo is not a clickable link.

Hence, we remove the link from the list of repositories and simply mark the text as bold in the dataset overview page:

![image](https://github.com/user-attachments/assets/acd55f84-9127-487a-bd13-edc00f34bcaf)
