### PR TITLE
State that tables can be previewed

### DIFF
--- a/audbcards/core/templates/datacard_tables.j2
+++ b/audbcards/core/templates/datacard_tables.j2
@@ -3,6 +3,8 @@
 Tables
 ^^^^^^
 
+Click on a row to toggle a preview.
+
 .. raw:: html
 
     <table class="clickable docutils align-default">

--- a/tests/test_data/rendered_templates/medium_db.rst
+++ b/tests/test_data/rendered_templates/medium_db.rst
@@ -44,6 +44,8 @@ Example
 Tables
 ^^^^^^
 
+Click on a row to toggle a preview.
+
 .. raw:: html
 
     <table class="clickable docutils align-default">

--- a/tests/test_data/rendered_templates/minimal_db.rst
+++ b/tests/test_data/rendered_templates/minimal_db.rst
@@ -29,6 +29,8 @@ Minimal database.
 Tables
 ^^^^^^
 
+Click on a row to toggle a preview.
+
 .. raw:: html
 
     <table class="clickable docutils align-default">


### PR DESCRIPTION
Closes #119 

As the rows listing the tables can be quite busy, we simply add a statement in front of the tables table, stating that you can click on the rows:

![image](https://github.com/user-attachments/assets/8943c8de-28b3-43f0-901a-7fa25476215e)

## Summary by Sourcery

Documentation:
- Add a statement above the tables indicating that rows can be clicked to toggle a preview.