### PR TITLE
Add audbcards_templates sphinx config setting

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -563,19 +563,19 @@ class Datacard(object):
                     "Using default templates only."
                 )
 
-            environment = jinja2.Environment(
-                loader=jinja2.ChoiceLoader(loaders),
-                trim_blocks=True,
-            )
-            template = environment.get_template("datacard.j2")
+        environment = jinja2.Environment(
+            loader=jinja2.ChoiceLoader(loaders),
+            trim_blocks=True,
+        )
+        template = environment.get_template("datacard.j2")
 
-            # Convert dataset object to dictionary
-            dataset = self.dataset._cached_properties()
+        # Convert dataset object to dictionary
+        dataset = self.dataset._cached_properties()
 
-            # Add additional datacard only properties
-            dataset = self._expand_dataset(dataset)
+        # Add additional datacard only properties
+        dataset = self._expand_dataset(dataset)
 
-            content = template.render(dataset)
+        content = template.render(dataset)
 
         # Add RST preamble
         if len(self.rst_preamble) > 0:

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -555,7 +555,7 @@ class Datacard(object):
         with tempfile.TemporaryDirectory() as tmpdir:
             for file in audeer.list_file_names(template_dir):
                 shutil.copyfile(file, os.path.join(tmpdir, os.path.basename(file)))
-            if self.template_dir is not None:
+            if self.template_dir is not None and os.path.isdir(self.template_dir):
                 # Overwrite with user defined templates
                 for file in audeer.list_file_names(self.template_dir):
                     shutil.copyfile(file, os.path.join(tmpdir, os.path.basename(file)))

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 import typing
+import warnings
 
 import jinja2
 import matplotlib.pyplot as plt
@@ -555,10 +556,18 @@ class Datacard(object):
         with tempfile.TemporaryDirectory() as tmpdir:
             for file in audeer.list_file_names(template_dir):
                 shutil.copyfile(file, os.path.join(tmpdir, os.path.basename(file)))
-            if self.template_dir is not None and os.path.isdir(self.template_dir):
-                # Overwrite with user defined templates
-                for file in audeer.list_file_names(self.template_dir):
-                    shutil.copyfile(file, os.path.join(tmpdir, os.path.basename(file)))
+            if self.template_dir is not None:
+                if os.path.exists(self.template_dir):
+                    # Overwrite with user defined templates
+                    for file in audeer.list_file_names(self.template_dir):
+                        shutil.copyfile(
+                            file, os.path.join(tmpdir, os.path.basename(file))
+                        )
+                else:
+                    warnings.warn(
+                        f"Template directory '{self.template_dir}' does not exist. "
+                        "Using default templates only."
+                    )
 
             environment = jinja2.Environment(
                 loader=jinja2.FileSystemLoader(tmpdir),

--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -29,6 +29,7 @@ def setup(app: sphinx.application.Sphinx):
         ],
         False,
     )
+    app.add_config_value("audbcards_templates", None, "html")
 
     # Connect functions to extension
     app.connect("builder-inited", builder_inited)
@@ -56,6 +57,7 @@ def builder_inited(app: sphinx.application.Sphinx):
     """
     # Read config values
     sections = app.config.audbcards_datasets
+    template_dir = os.path.join(app.srcdir, app.config.audbcards_templates)
 
     # Add CSS and JS files for table preview feature
     static_dir = audeer.mkdir(app.builder.outdir, "_static")
@@ -98,6 +100,7 @@ def builder_inited(app: sphinx.application.Sphinx):
                 path=path,
                 sphinx_build_dir=app.builder.outdir,
                 sphinx_src_dir=app.srcdir,
+                template_dir=template_dir,
                 example=example,
             )
             rst_file = os.path.join(

--- a/docs/_templates/datacard_header.j2
+++ b/docs/_templates/datacard_header.j2
@@ -1,0 +1,32 @@
+.. _{{ path }}-{{ name }}:
+
+{{ name }}
+{% for n in range(name|length) %}-{% endfor %}
+
+{% if author is not none %}
+
+Created by {{ author }}
+{% endif %}
+
+============= ======================
+version       {{ version }}
+{% if license_link is not none %}
+license       `{{ license }} <{{ license_link }}>`__
+{% else %}
+license       {{ license }}
+{% endif %}
+usage         {{ usage }}
+{% if languages is defined %}
+languages     {{ languages|join(', ') }}
+{% endif %}
+format        {{ formats|join(', ') }}
+channel       {{ channels|join(', ') }}
+sampling rate {{ sampling_rates|join(', ') }}
+bit depth     {{ bit_depths|join(', ') }}
+duration      {{ duration }}
+files         {{ files }}, duration distribution: {{ file_duration_distribution }}
+{% if segments != "0" %}
+segments      {{ segments }}, duration distribution: {{ segment_duration_distribution }}
+{% endif %}
+repository    {{ repository }}
+============= ======================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ audbcards_datasets = [
         True,
     ),
 ]
+audbcards_templates = "_templates"
 
 
 # HTML --------------------------------------------------------------------

--- a/docs/sphinx-extension.rst
+++ b/docs/sphinx-extension.rst
@@ -112,6 +112,12 @@ e.g. in ``docs/index.rst`` you could then write:
         data-public
         data-private
 
+A user can also influence
+how the resulting datacard appears,
+by setting the config the ``audbcards_templates`` folder.
+The value needs to be relative to the sphinx source dir
+(e.g. ``docs/``).
+
 
 Referencing
 -----------


### PR DESCRIPTION
Adds the possibility to provide user defined templates to overwrite the default templates when building datacards.
To achieve this, the `audbcards_templates` config value is added to the sphinx extension, and the `template_dir` argument is added to `audbcards.Datacard`.

It is also used to shorten the datacard header table in the example docs to

![image](https://github.com/user-attachments/assets/359abb0d-e256-40fc-9abd-443ff8677ca4)

## Summary by Sourcery

Add support for user-defined templates in datacards by introducing a 'template_dir' argument in the 'audbcards.Datacard' class and a new Sphinx configuration setting 'audbcards_templates'. This allows users to override default templates with their own when building datacards.

New Features:
- Introduce the ability to use user-defined templates for datacards by adding a 'template_dir' argument to the 'audbcards.Datacard' class.

Enhancements:
- Add a new Sphinx configuration setting 'audbcards_templates' to specify custom template directories.