### PR TITLE
DOC: switch to audb-public S3 repository

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Ubuntu - install libsndfile
+    - name: Ubuntu - install audio + video handling
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,11 @@ jobs:
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
 
+    - name: Ubuntu - install audio + video handling
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
+
     - name: Build documentation
       run: python -m sphinx docs/ build/html -b html
 

--- a/.github/workflows/test-sphinx.yml
+++ b/.github/workflows/test-sphinx.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Ubuntu - install libsndfile
+    - name: Ubuntu - install audio + video handling
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,12 +42,12 @@ intersphinx_mapping = {
 # Configure audbcards extension
 audbcards_datasets = [
     (
-        "data-public",
-        "data-public",
+        "audb-public",
+        "audb-public",
         audb.Repository(
-            name="data-public",
-            host="https://audeering.jfrog.io/artifactory",
-            backend="artifactory",
+            name="audb-public",
+            host="s3.dualstack.eu-north-1.amazonaws.com",
+            backend="s3",
         ),
         True,
     ),
@@ -61,6 +61,7 @@ html_theme_options = {
     "display_version": True,
     "logo_only": False,
     "footer_links": False,
+    "wide_pages": ["audb-public"],
 }
 html_context = {
     "display_github": True,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@
     :maxdepth: 2
     :hidden:
 
-    data-public
+    audb-public
 
 .. Warning: the usage of genindex is a hack to get a TOC entry, see
 .. https://stackoverflow.com/a/42310803. This might break the usage of sphinx if

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+audb >=1.11.0
 audbcards
 sphinx
 sphinx-apipages

--- a/docs/sphinx-extension.rst
+++ b/docs/sphinx-extension.rst
@@ -128,11 +128,11 @@ e.g.
 
 .. code-block:: rst
 
-    A list of public datasets is shown at :ref:`data-public`.
+    A list of public datasets is shown at :ref:`audb-public`.
 
 Which will render as:
 
-    A list of public datasets is shown at :ref:`data-public`.
+    A list of public datasets is shown at :ref:`audb-public`.
 
 And you can reference single data cards
 by a combination of their folder
@@ -141,11 +141,11 @@ e.g.
 
 .. code-block:: rst
 
-    :ref:`data-public-emodb` shows the data card for emodb.
+    :ref:`audb-public-emodb` shows the data card for emodb.
 
 Which will render as:
 
-    :ref:`data-public-emodb` shows the data card for emodb.
+    :ref:`audb-public-emodb` shows the data card for emodb.
 
 
 List of available datasets


### PR DESCRIPTION
Switch to new default public `audb` repository on S3, and ensure the available dataset page is shown in full page width.

## Summary by Sourcery

Documentation:
- Switch to the new default public 'audb' repository on S3 for documentation.