### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Ubuntu - install libsndfile
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediafile
 
     - name: Install package
       run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Ubuntu - install libsndfile
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediafile
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
 
     - name: Install package
       run: |

--- a/.github/workflows/test-sphinx.yml
+++ b/.github/workflows/test-sphinx.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Ubuntu - install libsndfile
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediafile
+
     - name: Set up ${{ matrix.sphinx }}
       run: |
         python -V

--- a/.github/workflows/test-sphinx.yml
+++ b/.github/workflows/test-sphinx.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Ubuntu - install libsndfile
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediafile
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
 
     - name: Set up ${{ matrix.sphinx }}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'


### PR DESCRIPTION
Adds Python 3.12 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.12 and update CI to test against it.

New Features:
- Add support for Python 3.12 in the project.

CI:
- Enable testing for Python 3.12 on Ubuntu runners in the CI workflow.