### PR TITLE
Fix sphinx extension for empty template dir

### DIFF
--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -57,7 +57,9 @@ def builder_inited(app: sphinx.application.Sphinx):
     """
     # Read config values
     sections = app.config.audbcards_datasets
-    template_dir = os.path.join(app.srcdir, app.config.audbcards_templates)
+    template_dir = app.config.audbcards_templates
+    if template_dir is not None:
+        template_dir = os.path.join(app.srcdir, template_dir)
 
     # Add CSS and JS files for table preview feature
     static_dir = audeer.mkdir(app.builder.outdir, "_static")


### PR DESCRIPTION
When no user defined template dir is provided, the sphinx extension was failing before as it tried to create a path with `None` included. We now skip this step if no template dir is provided.

## Summary by Sourcery

Bug Fixes:
- Fix the issue in the Sphinx extension where a path was incorrectly created with 'None' when no user-defined template directory was provided.