### PR TITLE
Show first entry for duplicated datasets

### DIFF
--- a/audbcards/sphinx/__init__.py
+++ b/audbcards/sphinx/__init__.py
@@ -82,6 +82,7 @@ def builder_inited(app: sphinx.application.Sphinx):
 
         print("Get list of available datasets... ", end="", flush=True)
         df = audb.available(only_latest=True)
+        df = df[~df.index.duplicated(keep="first")]
         df = df.sort_index()
         print("done")
 


### PR DESCRIPTION
If the same dataset and version are published at different repositories, it leads to an error as the same dataset is returned twice by `audb.available()`. This is fixed here, by documenting only the first appearance of a given dataset name + version combination.

## Summary by Sourcery

Bug Fixes:
- Fix issue where duplicated datasets with the same name and version from different repositories cause errors by retaining only the first occurrence.