### PR TITLE
CI: add test for sphinx 8.*

### DIFF
--- a/.github/workflows/test-sphinx.yml
+++ b/.github/workflows/test-sphinx.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         python-version: [ '3.10' ]
-        sphinx: [ 'sphinx==5.3.0', 'sphinx==6.2.1', 'sphinx==7.*' ]
+        sphinx: [ 'sphinx==5.3.0', 'sphinx==6.2.1', 'sphinx==7.4.7', 'sphinx==8.*' ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

Update CI configuration to explicitly test Sphinx 7.4.7 and include Sphinx 8.x series

CI:
- Add Sphinx 8.* to the GitHub Actions test matrix
- Pin the Sphinx 7 entry to version 7.4.7