### PR TITLE
CI: use Python 3.10 for linter Action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install pre-commit hooks
       run: |

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -551,8 +551,8 @@ class TestDatasetLoadTables:
 
         """
         self.dataset = audbcards.Dataset(
-            self.__class__name,
-            self.__class__version,
+            self.__class__.name,
+            self.__class__.version,
             cache_root=self.__class__.cache_root,
             load_tables=load_tables,
         )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -551,9 +551,9 @@ class TestDatasetLoadTables:
 
         """
         self.dataset = audbcards.Dataset(
-            self.name,
-            self.version,
-            cache_root=self.cache_root,
+            self.__class__name,
+            self.__class__version,
+            cache_root=self.__class__.cache_root,
             load_tables=load_tables,
         )
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -507,9 +507,8 @@ def test_dataset_parse_text(text, expected):
 class TestDatasetLoadTables:
     r"""Test load_tables argument of audbcards.Dataset."""
 
-    @classmethod
     @pytest.fixture(autouse=True)
-    def prepare(cls, cache, medium_db):
+    def prepare(self, cache, medium_db):
         r"""Provide test class with cache, database name and database version.
 
         Args:
@@ -517,9 +516,9 @@ class TestDatasetLoadTables:
             medium_db: medium_db fixture
 
         """
-        cls.name = medium_db.name
-        cls.version = pytest.VERSION
-        cls.cache_root = cache
+        self.name = medium_db.name
+        self.version = pytest.VERSION
+        self.cache_root = cache
 
     def assert_has_table_properties(self, expected: bool):
         r"""Assert dataset holds table related cached properties.
@@ -551,9 +550,9 @@ class TestDatasetLoadTables:
 
         """
         self.dataset = audbcards.Dataset(
-            self.__class__.name,
-            self.__class__.version,
-            cache_root=self.__class__.cache_root,
+            self.name,
+            self.version,
+            cache_root=self.cache_root,
             load_tables=load_tables,
         )
 


### PR DESCRIPTION
Fixes the `linter` Action by using Pyton 3.10 instead of 3.8.

It also changes a classmethod to a normal method in some of the test definitions as the class attributes set in that method can no longer be accessed by `self` in Python 3.13.

## Summary by Sourcery

CI:
- Use Python 3.10 in the linter Action instead of 3.8