### PR TITLE
Dataset.file_durations: exclude empty durations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,14 @@ jobs:
         sudo apt-get install --no-install-recommends --yes libsndfile1
       if: matrix.os == 'ubuntu-latest'
 
+    - name: OSX - install mediainfo
+      run: brew install mediainfo
+      if: matrix.os == 'macOS-latest'
+
+    - name: Windows - install mediainfo
+      run: choco install mediainfo-cli
+      if: matrix.os == 'windows-latest'
+
     - name: Sync Python environment
       run: uv sync
 

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -340,7 +340,7 @@ class _Dataset:
     @functools.cached_property
     def file_durations(self) -> typing.List:
         r"""File durations in dataset in seconds."""
-        return [self.deps.duration(file) for file in self.deps.media]
+        return [dur for file in self.deps.media if (dur := self.deps.duration(file))]
 
     @functools.cached_property
     def formats(self) -> typing.List[str]:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -339,7 +339,13 @@ class _Dataset:
 
     @functools.cached_property
     def file_durations(self) -> typing.List:
-        r"""File durations in dataset in seconds."""
+        r"""File durations in dataset in seconds.
+
+        Non media files,
+        or media files containing 0 samples
+        are excluded from this list.
+
+        """
         return [dur for file in self.deps.media if (dur := self.deps.duration(file))]
 
     @functools.cached_property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,6 @@ def bare_db(
     repository,
     audb_cache,
     scope="session",
-    autouse=True,
 ):
     r"""Publish and load a bare database.
 
@@ -90,7 +89,6 @@ def minimal_db(
     repository,
     audb_cache,
     scope="session",
-    autouse=True,
 ):
     r"""Publish and load a minimal database.
 
@@ -143,7 +141,6 @@ def medium_db(
     repository,
     audb_cache,
     scope="session",
-    autouse=True,
 ):
     r"""Publish and load a medium test database.
 
@@ -238,7 +235,6 @@ def mixed_db(
     repository,
     audb_cache,
     scope="session",
-    autouse=True,
 ):
     r"""Publish and load a mixed database.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import typing
 
@@ -221,6 +222,69 @@ def medium_db(
     # Create audio files and store database
     durations = [1, 301]
     create_audio_files(db, db_path, durations)
+    db.save(db_path)
+
+    # Publish and load database
+    audb.publish(db_path, pytest.VERSION, repository)
+    db = audb.load(name, version=pytest.VERSION, verbose=False)
+    tmp_root = str(tmpdir.parts()[1])
+    assert db.root.startswith(tmp_root)
+    return db
+
+
+@pytest.fixture
+def mixed_db(
+    tmpdir,
+    repository,
+    audb_cache,
+    scope="session",
+    autouse=True,
+):
+    r"""Publish and load a mixed database.
+
+    The name of the database will be ``mixed_db``.
+
+    The database contains one WAV and one JSON file,
+    and corresponding ``"audio"`` and ``"json"`` tables.
+
+    """
+    name = "mixed_db"
+
+    db_path = audeer.mkdir(audeer.path(tmpdir, name))
+
+    db = audformat.Database(
+        name=name,
+        source="https://github.com/audeering/audbcards",
+        usage="unrestricted",
+        expires=None,
+        languages=[],
+        description="Mixed database.",
+        author="H Wierstorf, C Geng, B E Abrougui",
+        license=audformat.define.License.CC0_1_0,
+    )
+
+    # Table 'audio'
+    db.schemes["transcription"] = audformat.Scheme("str")
+    index = audformat.filewise_index(["f0.wav"])
+    db["audio"] = audformat.Table(index)
+    db["audio"]["transcription"] = audformat.Column()
+    db["audio"]["transcription"].set(["Hello World"])
+    path = audeer.path(db_path, "f0.wav")
+    sampling_rate = 8000
+    signal = np.random.normal(0, 0.1, (1, int(0.1 * sampling_rate)))  # 0.1 s
+    audiofile.write(path, signal, sampling_rate, normalize=True)
+
+    # Table 'json'
+    db.schemes["turns"] = audformat.Scheme("int")
+    index = audformat.filewise_index(["c0.json"])
+    db["json"] = audformat.Table(index)
+    db["json"]["turns"] = audformat.Column()
+    db["json"]["turns"].set([1])
+    path = audeer.path(db_path, "c0.json")
+    var = {"role": "human", "text": "Hello World"}
+    with open(path, "w", encoding="utf-8") as fp:
+        json.dump(var, fp, ensure_ascii=False, indent=2)
+
     db.save(db_path)
 
     # Publish and load database

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,23 +265,36 @@ def mixed_db(
 
     # Table 'audio'
     db.schemes["transcription"] = audformat.Scheme("str")
-    index = audformat.filewise_index(["f0.wav"])
+    index = audformat.filewise_index(["f0.wav", "f1.wav"])
     db["audio"] = audformat.Table(index)
     db["audio"]["transcription"] = audformat.Column()
-    db["audio"]["transcription"].set(["Hello World"])
-    path = audeer.path(db_path, "f0.wav")
+    db["audio"]["transcription"].set(["Hello World", ""])
     sampling_rate = 8000
+    path = audeer.path(db_path, "f0.wav")
     signal = np.random.normal(0, 0.1, (1, int(0.1 * sampling_rate)))  # 0.1 s
     audiofile.write(path, signal, sampling_rate, normalize=True)
+    path = audeer.path(db_path, "f1.wav")
+    signal = np.random.normal(0, 0.1, (1, 0))  # 0.0 s
+    audiofile.write(path, signal, sampling_rate, normalize=False)
 
     # Table 'json'
     db.schemes["turns"] = audformat.Scheme("int")
     index = audformat.filewise_index(["c0.json"])
     db["json"] = audformat.Table(index)
     db["json"]["turns"] = audformat.Column()
-    db["json"]["turns"].set([1])
+    db["json"]["turns"].set([2])
     path = audeer.path(db_path, "c0.json")
-    var = {"role": "human", "text": "Hello World"}
+    var = [
+        {
+            "role": "human",
+            "audio": "f0.wav",
+            "transcription": "Hello World",
+        },
+        {
+            "role": "assistant",
+            "audio": "f1.wav",
+        },
+    ]
     with open(path, "w", encoding="utf-8") as fp:
         json.dump(var, fp, ensure_ascii=False, indent=2)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,7 +7,6 @@ import pytest
 
 import audb
 import audeer
-import audiofile
 
 import audbcards
 
@@ -168,11 +167,9 @@ def test_dataset(
     expected_bit_depths = sorted(
         list(
             set(
-                [
-                    bit_depth
-                    for file in expected_deps.media
-                    if (bit_depth := audiofile.bit_depth(file))
-                ]
+                bit_depth
+                for file in expected_deps.media
+                if (bit_depth := expected_deps.bit_depth(file))
             )
         )
     )
@@ -182,11 +179,9 @@ def test_dataset(
     expected_channels = sorted(
         list(
             set(
-                [
-                    channel
-                    for file in expected_deps.media
-                    if (channel := expected_deps.channels(file))
-                ]
+                channel
+                for file in expected_deps.media
+                if (channel := expected_deps.channels(file))
             )
         )
     )
@@ -208,7 +203,7 @@ def test_dataset(
 
     # formats
     expected_formats = sorted(
-        list(set([audeer.file_extension(file) for file in db.files]))
+        list(set(audeer.file_extension(file) for file in db.files))
     )
     assert dataset.formats == expected_formats
 
@@ -247,11 +242,9 @@ def test_dataset(
     expected_sampling_rates = sorted(
         list(
             set(
-                [
-                    sr
-                    for file in expected_deps.media
-                    if (sr := expected_deps.sampling_rate(file))
-                ]
+                sr
+                for file in expected_deps.media
+                if (sr := expected_deps.sampling_rate(file))
             )
         )
     )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -170,7 +170,7 @@ def test_dataset(
             set(
                 [
                     bit_depth
-                    for file in db.files
+                    for file in expected_deps.media
                     if (bit_depth := audiofile.bit_depth(file))
                 ]
             )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -108,7 +108,7 @@ def test_dataset_property_scope(tmpdir, db, request):
                 ["json", "filewise", "turns"],
             ],
             {"audio": 1, "json": 1},
-            {"audio": 1, "json": 1},
+            {"audio": 2, "json": 1},
             [],
         ),
     ],
@@ -196,6 +196,7 @@ def test_dataset(
         dur for file in expected_deps.media if (dur := expected_deps.duration(file))
     ]
     assert dataset.file_durations == expected_file_durations
+    assert all([d > 0 for d in dataset.file_durations])
 
     # duration
     expected_duration = sum(expected_file_durations)


### PR DESCRIPTION
Exclude file durations of 0 s from `audbcards.Dataset.file_durations`.

Those durations are set if we have non audio files (in the new test we have a JSON file), or when an audio/video file has a duration of 0 samples. We might be interested in still counting the 0.0 s for the later case, but we have no easy mechanism to decide if a given file should be a mediafile or not. Hence, I decided to just remove all 0.0 s entries to highlight actual duration in the duration plots, and avoid something like

![image](https://github.com/user-attachments/assets/3172a274-40e2-44ab-8548-97955537d818)

![image](https://github.com/user-attachments/assets/c9850634-0860-4dd6-8753-2006d2c0325c)

## Summary by Sourcery

Exclude empty (0 s) file durations from Dataset.file_durations and adjust dataset metrics and tests to ignore zero-length and non-audio files

Bug Fixes:
- Filter out 0.0 s durations in Dataset.file_durations to omit empty or non-media files from duration outputs

Enhancements:
- Recompute dataset duration, channels, sampling rates, and bit depths by filtering out zero or None values

Tests:
- Introduce a 'mixed_db' fixture with audio and JSON files to test filtering of non-audio entries
- Update test_dataset to use assignment expressions and exclude zero-length files in expected metric calculations