### PR TITLE
Fix speaker scheme labels

### DIFF
--- a/audbcards/core/utils.py
+++ b/audbcards/core/utils.py
@@ -46,12 +46,15 @@ def format_schemes(
                 # Keys are the same for all entries,
                 # using the first one is enough
                 labels = list(labels[0].keys())
-                speaker = [{scheme: labels}]
+                if labels:
+                    speaker = [{scheme: labels}]
+                else:
+                    speaker = [scheme]
                 max_schemes -= 1
             except KeyError:
-                emotion = [scheme]
+                speaker = [scheme]
             except AttributeError:
-                emotion = [scheme]
+                speaker = [scheme]
         else:
             filtered_schemes.append(scheme)
     # Force emotion and speaker to the beginning of the list

--- a/audbcards/core/utils.py
+++ b/audbcards/core/utils.py
@@ -51,9 +51,7 @@ def format_schemes(
                 else:
                     speaker = [scheme]
                 max_schemes -= 1
-            except KeyError:
-                speaker = [scheme]
-            except AttributeError:
+            except (KeyError, AttributeError):
                 speaker = [scheme]
         else:
             filtered_schemes.append(scheme)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,6 +7,7 @@ import pytest
 
 import audb
 import audeer
+import audformat
 
 import audbcards
 
@@ -529,6 +530,24 @@ def test_dataset_cache_loading(audb_cache, tmpdir, repository, db, request):
 def test_dataset_parse_text(text, expected):
     """Test parsing of text."""
     assert audbcards.Dataset._parse_text(text) == expected
+
+
+def test_dataset_scheme_summary(tmpdir, repository, audb_cache):
+    """Test scheme_summary attribute."""
+    # Create dataset using speaker scheme labels
+    # (https://github.com/audeering/audbcards/issues/118)
+    name = "db"
+    db_path = audeer.mkdir(audeer.path(tmpdir, name))
+    db = audformat.Database(name=name)
+    db.schemes["speaker"] = audformat.Scheme("str", labels=["s0", "s1"])
+    db.save(db_path)
+
+    # Publish and load database
+    version = "1.0.0"
+    audb.publish(db_path, version, repository)
+
+    ds = audbcards.Dataset(name, version)
+    assert ds.schemes_summary == "speaker"
 
 
 class TestDatasetLoadTables:


### PR DESCRIPTION
Closes https://github.com/audeering/audbcards/issues/118

Fixed `audbcards.Dataset.schemes_summary` for the case of speaker labels provided as a list. In this case there are no extra speaker information available, and it should simply return `speaker` as scheme name.

I added a test for the reported issue and updated the code to fix it.

## Summary by Sourcery

Fix handling of speaker scheme labels in `Dataset.schemes_summary` when provided as a list so that it returns the scheme name and add a test for this scenario.

Bug Fixes:
- Fix `schemes_summary` to return just the speaker scheme name when labels are given as a list without extra information.

Tests:
- Add a test for `Dataset.schemes_summary` using speaker scheme labels provided as a list.