### PR TITLE
Ensure JSON media example is formatted

### DIFF
--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 import functools
+import json
 import os
 import shutil
 import textwrap
@@ -201,9 +202,9 @@ class Datacard(object):
             version=self.dataset.version,
             verbose=False,
         )[0]
-        # Read json content as string
+        # Read json content and format with consistent indentation
         with open(json_file, encoding="utf-8") as fp:
-            content = fp.read()
+            content = json.dumps(json.load(fp), indent=2)
 
         # String holding the RST code to include the json
         return ".. code:: json\n" "\n" f"{textwrap.indent(content, '  ')}\n"

--- a/audbcards/core/datacard.py
+++ b/audbcards/core/datacard.py
@@ -204,7 +204,7 @@ class Datacard(object):
         )[0]
         # Read json content and format with consistent indentation
         with open(json_file, encoding="utf-8") as fp:
-            content = json.dumps(json.load(fp), indent=2)
+            content = json.dumps(json.load(fp), ensure_ascii=False, indent=2)
 
         # String holding the RST code to include the json
         return ".. code:: json\n" "\n" f"{textwrap.indent(content, '  ')}\n"

--- a/tests/test_datacard.py
+++ b/tests/test_datacard.py
@@ -1,9 +1,11 @@
+import json
 import os
 import re
 
 import matplotlib.pyplot as plt
 import pytest
 
+import audb
 import audeer
 import audiofile
 import audplot
@@ -49,6 +51,54 @@ def test_datacard(tmpdir, db, cache, request):
         expected_content = re.sub(pattern, "", expected_content)
 
     assert content == expected_content
+
+
+def test_datacard_json_formatting(cache, json_db):
+    r"""Test Datacard.json always returns formatted JSON.
+
+    Even when the source JSON file uses compact
+    single-line formatting,
+    the output should be pretty-printed
+    with an indent of 2.
+
+    """
+    dataset = audbcards.Dataset(json_db.name, pytest.VERSION, cache_root=cache)
+    datacard = audbcards.Datacard(dataset, cache_root=cache)
+
+    expected = (
+        ".. code:: json\n"
+        "\n"
+        "  [\n"
+        "    {\n"
+        '      "role": "human",\n'
+        '      "text": "What\'s the weather?"\n'
+        "    },\n"
+        "    {\n"
+        '      "role": "assistant",\n'
+        '      "text": "Nice"\n'
+        "    }\n"
+        "  ]\n"
+    )
+
+    # Verify formatting with already well-formatted JSON
+    result = datacard.json()
+    assert result == expected
+
+    # Overwrite cached JSON file with compact single-line format
+    json_file = audb.load_media(
+        dataset.name,
+        dataset.example_json,
+        version=dataset.version,
+        verbose=False,
+    )[0]
+    with open(json_file, encoding="utf-8") as fp:
+        data = json.load(fp)
+    with open(json_file, "w", encoding="utf-8") as fp:
+        json.dump(data, fp, separators=(",", ":"))
+
+    # Verify output is still properly formatted
+    result = datacard.json()
+    assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Ensure the JSON example shown on a data card is always shown as multiline with an indention of 2, even when the input is a single line JSON file as it is the default with `audeer.save_json()`.

## Summary by Sourcery

Format JSON examples in data cards with consistent pretty-printed output regardless of the source file formatting.

Bug Fixes:
- Ensure data card JSON output is consistently pretty-printed with 2-space indentation even when the underlying JSON file is in compact single-line format.

Tests:
- Add regression test verifying that Datacard.json always returns consistently formatted, indented JSON for both preformatted and compact source JSON files.