### PR TITLE
Fix Dataset.example_media

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -327,22 +327,32 @@ class _Dataset:
         # Pick a meaningful duration for the example audio file
         min_dur = 0.5
         max_dur = 300  # 5 min
-        durations = self.file_durations
-        selected_durations = [d for d in durations if d >= min_dur and d <= max_dur]
+        # Build list of (media_file, duration) pairs,
+        # keeping only files with non-zero duration
+        media_durations = [
+            (file, dur) for file in self.deps.media if (dur := self.deps.duration(file))
+        ]
+        selected = [
+            (file, dur)
+            for file, dur in media_durations
+            if dur >= min_dur and dur <= max_dur
+        ]
 
-        if len(selected_durations) == 0:
+        if len(selected) == 0:
             return None
 
-        selected_duration = np.median(selected_durations)
-        # Get index for duration closest to selected duration
+        selected_duration = np.median([dur for _, dur in selected])
+        # Get entry with duration closest to selected duration
         # see https://stackoverflow.com/a/9706105
-        # durations.index(selected_duration)
-        # is an alternative but fails due to rounding errors
         index = min(
-            range(len(durations)),
-            key=lambda n: abs(durations[n] - selected_duration),
+            range(len(media_durations)),
+            key=lambda n: abs(media_durations[n][1] - selected_duration),
         )
-        return self.deps.media[index] if self._files_in_archive(index) < 100 else None
+        file = media_durations[index][0]
+        archives = self.deps().archive
+        file_archive = self.deps.archive(file)
+        n_files_in_archive = (archives == file_archive).sum()
+        return file if n_files_in_archive < 100 else None
 
     @functools.cached_property
     def files(self) -> int:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -306,7 +306,8 @@ class _Dataset:
         if not json_idx:
             return None
         index = rng.choice(json_idx)
-        return self.deps.files[index] if self._files_in_archive(index) < 100 else None
+        file = self.deps.files[index]
+        return file if self._files_in_archive(file) < 100 else None
 
     @functools.cached_property
     def example_media(self) -> str | None:
@@ -327,27 +328,23 @@ class _Dataset:
         # Pick a meaningful duration for the example audio file
         min_dur = 0.5
         max_dur = 300  # 5 min
+
         media_durations = self._media_with_durations
-        selected = [
+        candidates = [
             (file, dur)
             for file, dur in media_durations
             if dur >= min_dur and dur <= max_dur
         ]
 
-        if len(selected) == 0:
+        if len(candidates) == 0:
             return None
 
-        selected_duration = np.median([dur for _, dur in selected])
-        # Get entry with duration closest to selected duration
-        # see https://stackoverflow.com/a/9706105
-        index = min(
-            range(len(media_durations)),
-            key=lambda n: abs(media_durations[n][1] - selected_duration),
-        )
-        file = media_durations[index][0]
-        file_archive = self.deps.archive(file)
-        n_files_in_archive = (self.deps.archives == file_archive).sum()
-        return file if n_files_in_archive < 100 else None
+        median_duration = np.median([dur for _, dur in candidates])
+
+        # pick file with duration closest to median
+        file, _ = min(candidates, key=lambda item: abs(item[1] - median_duration))
+
+        return file if self._files_in_archive(file) < 100 else None
 
     @functools.cached_property
     def files(self) -> int:
@@ -677,19 +674,19 @@ class _Dataset:
         )
         return props
 
-    def _files_in_archive(self, index: int) -> int:
+    def _files_in_archive(self, file: str) -> int:
         """Number of files in archive for given file index.
 
         Args:
-            index: index in dependency table
+            file: file in dependency table
 
         Returns:
-            number of files stored in the archive for given index
+            number of files stored in the archive for given file
 
         """
         archives = self.deps().archive
-        selected_archive = archives.iloc[index]
-        return (archives == selected_archive).sum()
+        file_archive = self.deps.archive(file)
+        return (archives == file_archive).sum()
 
     def _load_backend(self) -> type[audbackend.interface.Base]:
         r"""Load backend object containing dataset."""

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -327,11 +327,7 @@ class _Dataset:
         # Pick a meaningful duration for the example audio file
         min_dur = 0.5
         max_dur = 300  # 5 min
-        # Build list of (media_file, duration) pairs,
-        # keeping only files with non-zero duration
-        media_durations = [
-            (file, dur) for file in self.deps.media if (dur := self.deps.duration(file))
-        ]
+        media_durations = self._media_with_durations
         selected = [
             (file, dur)
             for file, dur in media_durations
@@ -360,6 +356,19 @@ class _Dataset:
         return len(self.deps.media)
 
     @functools.cached_property
+    def _media_with_durations(self) -> list[tuple[str, float]]:
+        r"""Media files paired with their durations.
+
+        Non media files,
+        or media files containing 0 samples
+        are excluded from this list.
+
+        """
+        return [
+            (file, dur) for file in self.deps.media if (dur := self.deps.duration(file))
+        ]
+
+    @functools.cached_property
     def file_durations(self) -> list:
         r"""File durations in dataset in seconds.
 
@@ -368,7 +377,7 @@ class _Dataset:
         are excluded from this list.
 
         """
-        return [dur for file in self.deps.media if (dur := self.deps.duration(file))]
+        return [dur for _, dur in self._media_with_durations]
 
     @functools.cached_property
     def formats(self) -> list[str]:

--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -345,9 +345,8 @@ class _Dataset:
             key=lambda n: abs(media_durations[n][1] - selected_duration),
         )
         file = media_durations[index][0]
-        archives = self.deps().archive
         file_archive = self.deps.archive(file)
-        n_files_in_archive = (archives == file_archive).sum()
+        n_files_in_archive = (self.deps.archives == file_archive).sum()
         return file if n_files_in_archive < 100 else None
 
     @functools.cached_property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,74 @@ def mixed_db(
     return db
 
 
+@pytest.fixture(scope="session")
+def mixed_media_db(
+    tmpdir_factory,
+    repository,
+    audb_cache,
+):
+    r"""Publish and load a database with WAV and JSON files.
+
+    The name of the database will be ``mixed_media_db``.
+
+    The database contains WAV files with valid durations
+    and a JSON file that sorts before them alphabetically.
+    This means ``deps.media`` is ordered as:
+
+        a0.json (0s), b0.wav (1s), b1.wav (2s), b2.wav (3s)
+
+    When zero-duration files are filtered out,
+    the resulting list ``[1, 2, 3]`` is shorter
+    and index N in the filtered list
+    no longer corresponds to index N in ``deps.media``.
+
+    """
+    name = "mixed_media_db"
+
+    db_path = tmpdir_factory.mktemp(name)
+
+    db = audformat.Database(
+        name=name,
+        source="https://github.com/audeering/audbcards",
+        usage="unrestricted",
+        expires=None,
+        languages=[],
+        description="Mixed media database.",
+        author="H Wierstorf",
+        license=audformat.define.License.CC0_1_0,
+    )
+
+    # Table 'audio' with WAV files named to sort after JSON
+    db.schemes["transcription"] = audformat.Scheme("str")
+    index = audformat.filewise_index(["b0.wav", "b1.wav", "b2.wav"])
+    db["audio"] = audformat.Table(index)
+    db["audio"]["transcription"] = audformat.Column()
+    db["audio"]["transcription"].set(["one", "two", "three"])
+    sampling_rate = 8000
+    for filename, duration in [("b0.wav", 1), ("b1.wav", 2), ("b2.wav", 3)]:
+        path = audeer.path(db_path, filename)
+        samples = int(duration * sampling_rate)
+        signal = np.random.normal(0, 0.1, (1, samples))
+        audiofile.write(path, signal, sampling_rate, normalize=True)
+
+    # Table 'json' with file that sorts before WAV files
+    db.schemes["turns"] = audformat.Scheme("int")
+    index = audformat.filewise_index(["a0.json"])
+    db["json"] = audformat.Table(index)
+    db["json"]["turns"] = audformat.Column()
+    db["json"]["turns"].set([1])
+    path = audeer.path(db_path, "a0.json")
+    with open(path, "w", encoding="utf-8") as fp:
+        json.dump({"role": "human"}, fp)
+
+    db.save(db_path)
+
+    # Publish and load database
+    audb.publish(db_path, pytest.VERSION, repository)
+    db = audb.load(name, version=pytest.VERSION, verbose=False)
+    return db
+
+
 def create_audio_files(
     db: audformat.Database,
     db_path: str,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -363,6 +363,23 @@ def test_dataset_example_media(db, cache, request):
     assert dataset.example_media == expected_example
 
 
+def test_dataset_example_media_mixed(cache, mixed_media_db):
+    r"""Test Dataset.example_media with mixed WAV and JSON files.
+
+    The database has deps.media ordered as:
+        a0.json (0s), b0.wav (1s), b1.wav (2s), b2.wav (3s)
+
+    The median of valid durations [1, 2, 3] is 2,
+    so example_media should return b1.wav.
+    A buggy implementation that indexes deps.media
+    with an index from the filtered durations list
+    would return b0.wav (off by one due to the skipped JSON).
+
+    """
+    dataset = audbcards.Dataset(mixed_media_db.name, pytest.VERSION, cache_root=cache)
+    assert dataset.example_media == "b1.wav"
+
+
 @pytest.mark.parametrize(
     "db, expected",
     [


### PR DESCRIPTION
Fix example media to work with mixed datasets that contain audio and json files. We did support json files already, but inside `example_media` we selected files based on `file_durations` which excludes already files with a duration of 0 (json files), but uses the returned index on all media files, including json files.

We now take care of tracking the remaining files as well.

## Summary by Sourcery

Fix Dataset.example_media to select a representative media file correctly when datasets contain a mix of audio and zero-duration JSON files.

Bug Fixes:
- Correct example_media selection by pairing media files with durations instead of relying on filtered duration indices that can desynchronize with deps.media.
- Ensure archive size checks are based on the selected media file rather than index-based lookups that may be misaligned.

Tests:
- Add a mixed-media database fixture combining WAV and JSON files to reproduce the index misalignment scenario.
- Add a regression test verifying example_media returns the correct WAV file for mixed-media datasets.