### PR TITLE
Require audb>=1.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audb >=1.7.0',
+    'audb >=1.12.0',
     'audeer >=2.2.0',
     'audiofile >=1.5.0',
     'audplot >=1.4.6',


### PR DESCRIPTION
Depend on newest `audb` version to allow speeding up of `audb.available()` in a next step.