### PR TITLE
Show example_json for archives of up to 1000 files

### DIFF
--- a/audbcards/core/dataset.py
+++ b/audbcards/core/dataset.py
@@ -296,7 +296,7 @@ class _Dataset:
 
         Path to example json file from dataset.
         The json file needs to be stored in an archive
-        with less than 100 files.
+        with at most 1000 files.
         If the json file does not meet this criterium
         or no json file is part of the dataset,
         ``None`` is returned instead.
@@ -307,7 +307,7 @@ class _Dataset:
             return None
         index = rng.choice(json_idx)
         file = self.deps.files[index]
-        return file if self._files_in_archive(file) < 100 else None
+        return file if self._files_in_archive(file) <= 1000 else None
 
     @functools.cached_property
     def example_media(self) -> str | None:
@@ -320,7 +320,7 @@ class _Dataset:
         between 0.5 s and 300 s.
         In addition,
         the media file needs to be stored in an archive
-        with less than 100 media files.
+        with less than 100 files.
         If no media file meets this criterium,
         ``None`` is returned instead.
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -399,6 +399,58 @@ def test_dataset_example_json(db, expected, cache, request):
     assert dataset.example_json == expected
 
 
+@pytest.mark.parametrize(
+    "files_in_archive, expected",
+    [
+        (1000, "c0.json"),
+        (1001, None),
+    ],
+)
+def test_dataset_example_json_archive_limit(
+    cache, mixed_db, monkeypatch, files_in_archive, expected
+):
+    r"""Test archive size limit of Dataset.example_json.
+
+    A json file is only selected as example
+    if it is stored in an archive
+    with at most 1000 files.
+
+    """
+    monkeypatch.setattr(
+        audbcards.core.dataset._Dataset,
+        "_files_in_archive",
+        lambda self, file: files_in_archive,
+    )
+    dataset = audbcards.Dataset(mixed_db.name, pytest.VERSION, cache_root=cache)
+    assert dataset.example_json == expected
+
+
+@pytest.mark.parametrize(
+    "files_in_archive, expected_example",
+    [
+        (99, True),
+        (100, False),
+    ],
+)
+def test_dataset_example_media_archive_limit(
+    cache, medium_db, monkeypatch, files_in_archive, expected_example
+):
+    r"""Test archive size limit of Dataset.example_media.
+
+    A media file is only selected as example
+    if it is stored in an archive
+    with less than 100 files.
+
+    """
+    monkeypatch.setattr(
+        audbcards.core.dataset._Dataset,
+        "_files_in_archive",
+        lambda self, file: files_in_archive,
+    )
+    dataset = audbcards.Dataset(medium_db.name, pytest.VERSION, cache_root=cache)
+    assert (dataset.example_media is not None) == expected_example
+
+
 @pytest.fixture
 def constructor(tmpdir, medium_db, request):
     """Fixture to test Dataset constructor."""


### PR DESCRIPTION
Closes #159 

Shows an example for a JSON file now for archives up to 1000 files (instead of <100).